### PR TITLE
be more tolerant of secret ARNs

### DIFF
--- a/checks/secrets-json-valid.js
+++ b/checks/secrets-json-valid.js
@@ -2,7 +2,7 @@ require('../typedefs');
 const core = require("@actions/core");
 const { getLinesForJSON, suggest, getLineWithinObject } = require("../util");
 
-const secretArn = /arn:(?<partition>[\w\*\-]*):secretsmanager:(?<region>[\w-]*):(?<account>\d*):secret:(?<secretName>[\w-\/]*):(?<jsonKey>\S*?):(?<versionStage>\S*?):(?<versionId>\w*)/;
+const secretArn = /arn:(?<partition>[\w\*\-]*):secretsmanager:(?<region>[\w-]*):(?<account>\d*):secret:(?<secretName>[\w-\/]*):?(?<jsonKey>\S*?):?(?<versionStage>\S*?):?(?<versionId>\w*)/;
 
 /**
  * Accepts a deployment object, and does some kind of check

--- a/test/secrets-json-valid.js
+++ b/test/secrets-json-valid.js
@@ -21,6 +21,10 @@ describe("secrets.json is valid check", () => {
       {
         "name": "OTHER_VALUE",
         "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:newkey::"
+      },
+      {
+        "name": "MORE_PLAIN",
+        "valueFrom": "arn:aws:secretsmanager:us-east-1:988857891049:secret:us-east-1/prototype/GDS_INSTANCES_PRIVATE_KEY-46S5sl"
       }
     ]`;
 


### PR DESCRIPTION
This check was previously more sensitive than AWS requires: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html

I have slightly modified the regex to be more tolerant, and extended a test case to validate it.