### PR TITLE
No carriage return characters

### DIFF
--- a/checks/index.js
+++ b/checks/index.js
@@ -15,6 +15,7 @@ module.exports = [
   require("./no-debug-in-prod"),
   require("./secrets-json-valid"),
   require("./secrets-in-orders"),
+  require("./no-carriage-return"),
 
   /**
    *  This should probably always be last, because it verifies that the

--- a/checks/no-carriage-return.js
+++ b/checks/no-carriage-return.js
@@ -18,6 +18,7 @@ async function noCarriageReturn(deployment, context, inputs) {
     return {
       title: "No Carriage Return Characters",
       problems: [
+        `${path} contains invalid newline characters.`,
         "You must use Unix-type newlines (`LF`). Windows-type newlines (`CRLF`) are not permitted.",
       ],
       line: 0,

--- a/checks/no-carriage-return.js
+++ b/checks/no-carriage-return.js
@@ -19,7 +19,7 @@ async function noCarriageReturn(deployment, context, inputs) {
       title: 'No Carriage Return Characters',
       problems: [
         'You must use Unix-type newlines (`\\n`). Windows-type newlines (`\\r\\n`) are not permitted.',
-        suggest('Delete the carriage return character', line.replace(/\r/g, '\n'))
+        suggest('Delete the carriage return character', line.replace(/\r/g, ''))
       ],
       line: lineNumber,
       level: 'failure',

--- a/checks/no-carriage-return.js
+++ b/checks/no-carriage-return.js
@@ -18,7 +18,7 @@ async function noCarriageReturn(deployment, context, inputs) {
     return {
       title: "No Carriage Return Characters",
       problems: [
-        `${path} contains invalid newline characters.`,
+        `\`${path}\` contains invalid newline characters.`,
         "You must use Unix-type newlines (`LF`). Windows-type newlines (`CRLF`) are not permitted.",
       ],
       line: 0,

--- a/checks/no-carriage-return.js
+++ b/checks/no-carriage-return.js
@@ -1,54 +1,50 @@
-require('../typedefs');
+require("../typedefs");
 const core = require("@actions/core");
-const { suggest } = require('../util');
+const { suggest } = require("../util");
 
 /**
  * Checks for windows-type carriage return characters, and suggests removing them.
  * @param {Deployment} deployment An object containing information about a deployment
  * @param {GitHubContext} context The context object provided by github
  * @param {ActionInputs} inputs The inputs (excluding the token) from the github action
- * 
+ *
  * @returns {Array<Result>}
  */
 async function noCarriageReturn(deployment, context, inputs) {
   core.info(`No Carriage Return Character - ${deployment.ordersPath}`);
   const results = [];
-  
-  function _removeCR(line, lineNumber, path) {
+
+  function _removeCR(path) {
     return {
-      title: 'No Carriage Return Characters',
+      title: "No Carriage Return Characters",
       problems: [
-        'You must use Unix-type newlines (`\\n`). Windows-type newlines (`\\r\\n`) are not permitted.',
-        suggest('Delete the carriage return character', line.replace(/\r/g, ''))
+        "You must use Unix-type newlines (`LF`). Windows-type newlines (`CRLF`) are not permitted.",
       ],
-      line: lineNumber,
-      level: 'failure',
-      path
-    }
+      line: 0,
+      level: "failure",
+      path,
+    };
   }
 
-  deployment.ordersContents.forEach((line, i) => {
-    if (line.includes('\r')) {
-      results.push(_removeCR(line, i + 1, deployment.ordersPath));
-    }
-  });
-
-  if (deployment.secretsContents) {
-    deployment.secretsContents.forEach((line, i) => {
-      if (line.includes('\r')) {
-        results.push(_removeCR(line, i + 1, deployment.secretsPath));
-      }
-    });
+  if (
+    deployment.ordersContents.filter((line) => line.includes("\r")).length > 0
+  ) {
+    results.push(_removeCR(deployment.ordersPath));
   }
 
-  if (deployment.policyContents) {
-    deployment.policyContents.forEach((line, i) => {
-      if (line.includes('\r')) {
-        results.push(_removeCR(line, i + 1, deployment.policyPath));
-      }
-    });
+  if (
+    deployment.secretsContents &&
+    deployment.secretsContents.filter((line) => line.includes("\r")).length > 0
+  ) {
+    results.push(_removeCR(deployment.secretsPath));
   }
-  
+
+  if (
+    deployment.policyContents &&
+    deployment.policyContents.filter((line) => line.includes("\r")).length > 0
+  ) {
+    results.push(_removeCR(deployment.policyPath));
+  }
 
   return results;
 }

--- a/checks/no-carriage-return.js
+++ b/checks/no-carriage-return.js
@@ -19,7 +19,7 @@ async function noCarriageReturn(deployment, context, inputs) {
       title: 'No Carriage Return Characters',
       problems: [
         'You must use Unix-type newlines (`\\n`). Windows-type newlines (`\\r\\n`) are not permitted.',
-        suggest('Delete the carriage return character', line.replace(/\r/g, ''))
+        suggest('Delete the carriage return character', line.replace(/\r/g, '\n'))
       ],
       line: lineNumber,
       level: 'failure',

--- a/checks/no-carriage-return.js
+++ b/checks/no-carriage-return.js
@@ -1,0 +1,56 @@
+require('../typedefs');
+const core = require("@actions/core");
+const { suggest } = require('../util');
+
+/**
+ * Checks for windows-type carriage return characters, and suggests removing them.
+ * @param {Deployment} deployment An object containing information about a deployment
+ * @param {GitHubContext} context The context object provided by github
+ * @param {ActionInputs} inputs The inputs (excluding the token) from the github action
+ * 
+ * @returns {Array<Result>}
+ */
+async function noCarriageReturn(deployment, context, inputs) {
+  core.info(`No Carriage Return Character - ${deployment.ordersPath}`);
+  const results = [];
+  
+  function _removeCR(line, lineNumber, path) {
+    return {
+      title: 'No Carriage Return Characters',
+      problems: [
+        'You must use Unix-type newlines (`\\n`). Windows-type newlines (`\\r\\n`) are not permitted.',
+        suggest('Delete the carriage return character', line.replace(/\r/g, ''))
+      ],
+      line: lineNumber,
+      level: 'failure',
+      path
+    }
+  }
+
+  deployment.ordersContents.forEach((line, i) => {
+    if (line.includes('\r')) {
+      results.push(_removeCR(line, i + 1, deployment.ordersPath));
+    }
+  });
+
+  if (deployment.secretsContents) {
+    deployment.secretsContents.forEach((line, i) => {
+      if (line.includes('\r')) {
+        results.push(_removeCR(line, i + 1, deployment.secretsPath));
+      }
+    });
+  }
+
+  if (deployment.policyContents) {
+    deployment.policyContents.forEach((line, i) => {
+      if (line.includes('\r')) {
+        results.push(_removeCR(line, i + 1, deployment.policyPath));
+      }
+    });
+  }
+  
+
+  return results;
+}
+
+module.exports = noCarriageReturn;

--- a/checks/no-carriage-return.js
+++ b/checks/no-carriage-return.js
@@ -1,6 +1,5 @@
 require("../typedefs");
 const core = require("@actions/core");
-const { suggest } = require("../util");
 
 /**
  * Checks for windows-type carriage return characters, and suggests removing them.

--- a/test/no-carriage-return.js
+++ b/test/no-carriage-return.js
@@ -1,50 +1,41 @@
-const { expect } = require('chai');
-const noCarriageReturn = require('../checks/no-carriage-return');
-const { suggest } = require('../util');
+const { expect } = require("chai");
+const noCarriageReturn = require("../checks/no-carriage-return");
 
-describe('No Carriage Return', () => {
-  it('accepts a file with no carriage returns', async () => {
+describe("No Carriage Return", () => {
+  it("accepts a file with no carriage returns", async () => {
     const deployment = {
-      ordersPath: 'streamliner/orders',
-      ordersContents: [
-        'export VAR=value',
-        '# A comment',
-        'export VARZ=valuez'
-      ]
-    }
+      ordersPath: "streamliner/orders",
+      ordersContents: ["export VAR=value", "# A comment", "export VARZ=valuez"],
+    };
 
     const results = await noCarriageReturn(deployment);
     expect(results.length).to.equal(0);
   });
 
-  it('suggests deleting carriage return characters from orders', async () => {
+  it("Rejects Orders file with CRLF", async () => {
     const deployment = {
-      ordersPath: 'streamliner/orders',
+      ordersPath: "streamliner/orders",
       ordersContents: [
-        'export VAR=value\r',
-        '# A comment\r',
-        'export VARZ=valuez\r'
-      ]
-    }
+        "export VAR=value\r",
+        "# A comment\r",
+        "export VARZ=valuez\r",
+      ],
+    };
 
     const results = await noCarriageReturn(deployment);
-    expect(results.length).to.equal(3);
-
-    results.forEach((result, i) => {
-      expect(result).to.deep.equal({
-        title: 'No Carriage Return Characters',
-        problems: [
-          'You must use Unix-type newlines (`\\n`). Windows-type newlines (`\\r\\n`) are not permitted.',
-          suggest('Delete the carriage return character', deployment.ordersContents[i].replace(/\r/g, ''))
-        ],
-        line: i + 1,
-        level: 'failure',
-        path: deployment.ordersPath
-      });
+    expect(results.length).to.equal(1);
+    expect(results[0]).to.deep.equal({
+      title: "No Carriage Return Characters",
+      problems: [
+        "You must use Unix-type newlines (`LF`). Windows-type newlines (`CRLF`) are not permitted.",
+      ],
+      line: 0,
+      level: "failure",
+      path: deployment.ordersPath,
     });
   });
 
-  it('suggests deleting carriage return characters from secrets.json', async () => {
+  it("Rejects secrets.json with CRLF", async () => {
     const secretsJson = `[\r
       {\r
         "name": "JSON_SECRET",\r
@@ -57,35 +48,26 @@ describe('No Carriage Return', () => {
     ]`;
 
     const deployment = {
-      ordersPath: 'streamliner/orders',
-      ordersContents: [
-        'export VAR=value',
-        '# A comment',
-        'export VARZ=valuez'
-      ],
-      secretsPath: 'streamliner/secrets.json',
-      secretsContents: secretsJson.split('\n')
-    }
+      ordersPath: "streamliner/orders",
+      ordersContents: ["export VAR=value", "# A comment", "export VARZ=valuez"],
+      secretsPath: "streamliner/secrets.json",
+      secretsContents: secretsJson.split("\n"),
+    };
 
     const results = await noCarriageReturn(deployment);
-    expect(results.length).to.equal(9);
-
-    // Every line in secrets.json except the last one will generate a failure result
-    results.forEach((result, i) => {
-      expect(result).to.deep.equal({
-        title: 'No Carriage Return Characters',
-        problems: [
-          'You must use Unix-type newlines (`\\n`). Windows-type newlines (`\\r\\n`) are not permitted.',
-          suggest('Delete the carriage return character', deployment.secretsContents[i].replace(/\r/g, ''))
-        ],
-        line: i + 1,
-        level: 'failure',
-        path: deployment.secretsPath
-      });
+    expect(results.length).to.equal(1);
+    expect(results[0]).to.deep.equal({
+      title: "No Carriage Return Characters",
+      problems: [
+        "You must use Unix-type newlines (`LF`). Windows-type newlines (`CRLF`) are not permitted.",
+      ],
+      line: 0,
+      level: "failure",
+      path: deployment.secretsPath,
     });
   });
 
-  it('suggests deleting carriage return characters from policy.json', async () => {
+  it("Rejects policy.json with CRLF", async () => {
     const policyJson = JSON.stringify(
       {
         Version: "2012-10-17",
@@ -108,34 +90,25 @@ describe('No Carriage Return', () => {
       },
       null,
       2
-    ).replace(/\n/g, '\r\n');
+    ).replace(/\n/g, "\r\n");
 
     const deployment = {
-      ordersPath: 'streamliner/orders',
-      ordersContents: [
-        'export VAR=value',
-        '# A comment',
-        'export VARZ=valuez'
-      ],
-      policyPath: 'streamliner/policy.json',
-      policyContents: policyJson.split('\n')
-    }
+      ordersPath: "streamliner/orders",
+      ordersContents: ["export VAR=value", "# A comment", "export VARZ=valuez"],
+      policyPath: "streamliner/policy.json",
+      policyContents: policyJson.split("\n"),
+    };
 
     const results = await noCarriageReturn(deployment);
-    expect(results.length).to.equal(17);
-
-    // Every line in policy.json except the last one will generate a failure result
-    results.forEach((result, i) => {
-      expect(result).to.deep.equal({
-        title: 'No Carriage Return Characters',
-        problems: [
-          'You must use Unix-type newlines (`\\n`). Windows-type newlines (`\\r\\n`) are not permitted.',
-          suggest('Delete the carriage return character', deployment.policyContents[i].replace(/\r/g, ''))
-        ],
-        line: i + 1,
-        level: 'failure',
-        path: deployment.policyPath
-      });
+    expect(results.length).to.equal(1);
+    expect(results[0]).to.deep.equal({
+      title: "No Carriage Return Characters",
+      problems: [
+        "You must use Unix-type newlines (`LF`). Windows-type newlines (`CRLF`) are not permitted.",
+      ],
+      line: 0,
+      level: "failure",
+      path: deployment.policyPath,
     });
   });
-})
+});

--- a/test/no-carriage-return.js
+++ b/test/no-carriage-return.js
@@ -27,6 +27,7 @@ describe("No Carriage Return", () => {
     expect(results[0]).to.deep.equal({
       title: "No Carriage Return Characters",
       problems: [
+        `${deployment.ordersPath} contains invalid newline characters.`,
         "You must use Unix-type newlines (`LF`). Windows-type newlines (`CRLF`) are not permitted.",
       ],
       line: 0,
@@ -59,6 +60,7 @@ describe("No Carriage Return", () => {
     expect(results[0]).to.deep.equal({
       title: "No Carriage Return Characters",
       problems: [
+        `${deployment.secretsPath} contains invalid newline characters.`,
         "You must use Unix-type newlines (`LF`). Windows-type newlines (`CRLF`) are not permitted.",
       ],
       line: 0,
@@ -104,6 +106,7 @@ describe("No Carriage Return", () => {
     expect(results[0]).to.deep.equal({
       title: "No Carriage Return Characters",
       problems: [
+        `${deployment.policyPath} contains invalid newline characters.`,
         "You must use Unix-type newlines (`LF`). Windows-type newlines (`CRLF`) are not permitted.",
       ],
       line: 0,

--- a/test/no-carriage-return.js
+++ b/test/no-carriage-return.js
@@ -1,0 +1,141 @@
+const { expect } = require('chai');
+const noCarriageReturn = require('../checks/no-carriage-return');
+const { suggest } = require('../util');
+
+describe('No Carriage Return', () => {
+  it('accepts a file with no carriage returns', async () => {
+    const deployment = {
+      ordersPath: 'streamliner/orders',
+      ordersContents: [
+        'export VAR=value',
+        '# A comment',
+        'export VARZ=valuez'
+      ]
+    }
+
+    const results = await noCarriageReturn(deployment);
+    expect(results.length).to.equal(0);
+  });
+
+  it('suggests deleting carriage return characters from orders', async () => {
+    const deployment = {
+      ordersPath: 'streamliner/orders',
+      ordersContents: [
+        'export VAR=value\r',
+        '# A comment\r',
+        'export VARZ=valuez\r'
+      ]
+    }
+
+    const results = await noCarriageReturn(deployment);
+    expect(results.length).to.equal(3);
+
+    results.forEach((result, i) => {
+      expect(result).to.deep.equal({
+        title: 'No Carriage Return Characters',
+        problems: [
+          'You must use Unix-type newlines (`\\n`). Windows-type newlines (`\\r\\n`) are not permitted.',
+          suggest('Delete the carriage return character', deployment.ordersContents[i].replace(/\r/g, ''))
+        ],
+        line: i + 1,
+        level: 'failure',
+        path: deployment.ordersPath
+      });
+    });
+  });
+
+  it('suggests deleting carriage return characters from secrets.json', async () => {
+    const secretsJson = `[\r
+      {\r
+        "name": "JSON_SECRET",\r
+        "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:example::"\r
+      },\r
+      {\r
+        "name": "OTHER_VALUE",\r
+        "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:newkey::"\r
+      }\r
+    ]`;
+
+    const deployment = {
+      ordersPath: 'streamliner/orders',
+      ordersContents: [
+        'export VAR=value',
+        '# A comment',
+        'export VARZ=valuez'
+      ],
+      secretsPath: 'streamliner/secrets.json',
+      secretsContents: secretsJson.split('\n')
+    }
+
+    const results = await noCarriageReturn(deployment);
+    expect(results.length).to.equal(9);
+
+    // Every line in secrets.json except the last one will generate a failure result
+    results.forEach((result, i) => {
+      expect(result).to.deep.equal({
+        title: 'No Carriage Return Characters',
+        problems: [
+          'You must use Unix-type newlines (`\\n`). Windows-type newlines (`\\r\\n`) are not permitted.',
+          suggest('Delete the carriage return character', deployment.secretsContents[i].replace(/\r/g, ''))
+        ],
+        line: i + 1,
+        level: 'failure',
+        path: deployment.secretsPath
+      });
+    });
+  });
+
+  it('suggests deleting carriage return characters from policy.json', async () => {
+    const policyJson = JSON.stringify(
+      {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: [
+              "ecr:GetAuthorizationToken",
+              "ecr:BatchCheckLayerAvailability",
+              "ecr:GetDownloadUrlForLayer",
+              "ecr:BatchGetImage",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "secretsmanager:GetSecretValue",
+            ],
+            Resource:
+              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+          },
+        ],
+      },
+      null,
+      2
+    ).replace(/\n/g, '\r\n');
+
+    const deployment = {
+      ordersPath: 'streamliner/orders',
+      ordersContents: [
+        'export VAR=value',
+        '# A comment',
+        'export VARZ=valuez'
+      ],
+      policyPath: 'streamliner/policy.json',
+      policyContents: policyJson.split('\n')
+    }
+
+    const results = await noCarriageReturn(deployment);
+    expect(results.length).to.equal(17);
+
+    // Every line in policy.json except the last one will generate a failure result
+    results.forEach((result, i) => {
+      expect(result).to.deep.equal({
+        title: 'No Carriage Return Characters',
+        problems: [
+          'You must use Unix-type newlines (`\\n`). Windows-type newlines (`\\r\\n`) are not permitted.',
+          suggest('Delete the carriage return character', deployment.policyContents[i].replace(/\r/g, ''))
+        ],
+        line: i + 1,
+        level: 'failure',
+        path: deployment.policyPath
+      });
+    });
+  });
+})

--- a/test/no-carriage-return.js
+++ b/test/no-carriage-return.js
@@ -27,7 +27,7 @@ describe("No Carriage Return", () => {
     expect(results[0]).to.deep.equal({
       title: "No Carriage Return Characters",
       problems: [
-        `${deployment.ordersPath} contains invalid newline characters.`,
+        `\`${deployment.ordersPath}\` contains invalid newline characters.`,
         "You must use Unix-type newlines (`LF`). Windows-type newlines (`CRLF`) are not permitted.",
       ],
       line: 0,
@@ -60,7 +60,7 @@ describe("No Carriage Return", () => {
     expect(results[0]).to.deep.equal({
       title: "No Carriage Return Characters",
       problems: [
-        `${deployment.secretsPath} contains invalid newline characters.`,
+        `\`${deployment.secretsPath}\` contains invalid newline characters.`,
         "You must use Unix-type newlines (`LF`). Windows-type newlines (`CRLF`) are not permitted.",
       ],
       line: 0,
@@ -106,7 +106,7 @@ describe("No Carriage Return", () => {
     expect(results[0]).to.deep.equal({
       title: "No Carriage Return Characters",
       problems: [
-        `${deployment.policyPath} contains invalid newline characters.`,
+        `\`${deployment.policyPath}\` contains invalid newline characters.`,
         "You must use Unix-type newlines (`LF`). Windows-type newlines (`CRLF`) are not permitted.",
       ],
       line: 0,


### PR DESCRIPTION
Windows uses `CRLF` instead of `LF` for newlines. This is not allowed, so this check looks for `CR` and yells about it.

Added test coverage, and tested in the wild here: https://github.com/glg/cc-screamer-testing.s99/pull/5