### PR TITLE
Check on all important changes

### DIFF
--- a/checks/deployment-line.js
+++ b/checks/deployment-line.js
@@ -26,6 +26,10 @@ function getDeployment(match) {
  * @returns {Array<Result>}
  */
 async function validateDeploymentLine(deployment) {
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
   core.info(`Valid Deployment Line - ${deployment.ordersPath}`);
 
   const problems = [];

--- a/checks/healthcheck.js
+++ b/checks/healthcheck.js
@@ -9,7 +9,10 @@ const { isAJob } = require('../util');
  * @returns {Array<Result>}
  */
 async function validateHealthcheck(deployment) {
-  
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
 
   const problems = [];
   let lineNumber = 0;

--- a/checks/https-only.js
+++ b/checks/https-only.js
@@ -17,6 +17,10 @@ const reBadURLs = new RegExp(
  * @returns {Array<Result>}
  */
 async function httpsOnly(deployment) {
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
   core.info(`HTTPS Only - ${deployment.ordersPath}`);
   const results = [];
 

--- a/checks/jwt-access-flags.js
+++ b/checks/jwt-access-flags.js
@@ -8,6 +8,10 @@ const core = require("@actions/core");
  * @returns {Array<Result>}
  */
 async function jwtAccessFlags(deployment) {
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
   core.info(`JWT Access Flags - ${deployment.ordersPath}`);
   const results = [];
 

--- a/checks/no-carriage-return.js
+++ b/checks/no-carriage-return.js
@@ -10,6 +10,10 @@ const core = require("@actions/core");
  * @returns {Array<Result>}
  */
 async function noCarriageReturn(deployment, context, inputs) {
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
   core.info(`No Carriage Return Character - ${deployment.ordersPath}`);
   const results = [];
 

--- a/checks/no-carriage-return.js
+++ b/checks/no-carriage-return.js
@@ -34,10 +34,10 @@ async function noCarriageReturn(deployment, context, inputs) {
   }
 
   if (
-    deployment.secretsContents &&
-    deployment.secretsContents.filter((line) => line.includes("\r")).length > 0
+    deployment.secretsJsonContents &&
+    deployment.secretsJsonContents.filter((line) => line.includes("\r")).length > 0
   ) {
-    results.push(_removeCR(deployment.secretsPath));
+    results.push(_removeCR(deployment.secretsJsonPath));
   }
 
   if (

--- a/checks/no-carriage-return.js
+++ b/checks/no-carriage-return.js
@@ -10,10 +10,6 @@ const core = require("@actions/core");
  * @returns {Array<Result>}
  */
 async function noCarriageReturn(deployment, context, inputs) {
-  if (!deployment.ordersContents) {
-    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
-    return [];
-  }
   core.info(`No Carriage Return Character - ${deployment.ordersPath}`);
   const results = [];
 
@@ -31,6 +27,7 @@ async function noCarriageReturn(deployment, context, inputs) {
   }
 
   if (
+    deployment.ordersContents &&
     deployment.ordersContents.filter((line) => line.includes("\r")).length > 0
   ) {
     results.push(_removeCR(deployment.ordersPath));

--- a/checks/no-carriage-return.js
+++ b/checks/no-carriage-return.js
@@ -44,10 +44,10 @@ async function noCarriageReturn(deployment, context, inputs) {
   }
 
   if (
-    deployment.policyContents &&
-    deployment.policyContents.filter((line) => line.includes("\r")).length > 0
+    deployment.policyJsonContents &&
+    deployment.policyJsonContents.filter((line) => line.includes("\r")).length > 0
   ) {
-    results.push(_removeCR(deployment.policyPath));
+    results.push(_removeCR(deployment.policyJsonPath));
   }
 
   return results;

--- a/checks/no-debug-in-prod.js
+++ b/checks/no-debug-in-prod.js
@@ -18,6 +18,10 @@ const debugs = [
  * @returns {Array<Result>}
  */
 async function noDebugInProd(deployment) {
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
   core.info(`No Debug In Production - ${deployment.ordersPath}`);
   const results = [];
  

--- a/checks/no-duplicate-exports.js
+++ b/checks/no-duplicate-exports.js
@@ -10,6 +10,10 @@ const exportedVariable = /^export +(?<variable>\w+)=/;
  * @returns {Array<Result>}
  */
 async function noDuplicateExports(deployment) {
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
   core.info(`No Duplicate Exports - ${deployment.ordersPath}`);
   const results = [];
 

--- a/checks/no-sourcing.js
+++ b/checks/no-sourcing.js
@@ -10,6 +10,10 @@ const sourceUse = /^source (.*)/;
  * @returns {Array<Result>}
  */
 async function noSourcing(deployment) {
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
   core.info(`No Sourcing Other Files - ${deployment.ordersPath}`);
   const results = [];
 

--- a/checks/no-spaces-in-exports.js
+++ b/checks/no-spaces-in-exports.js
@@ -10,6 +10,10 @@ const exportLine = /^export\s(?<variable>.*?)\s*=\s*(?<value>.*)/i;
  * @returns {Array<Result>}
  */
 async function noSpacesInExports(deployment) {
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
   core.info(`No Spaces in Exports - ${deployment.ordersPath}`);
   const results = [];
 

--- a/checks/policy-json-valid.js
+++ b/checks/policy-json-valid.js
@@ -74,7 +74,7 @@ async function policyJsonIsValid(deployment) {
 
   // Secrets access is only needed for services that use secrets
   const secretsAction = "secretsmanager:GetSecretValue";
-  if (deployment.secretsContents) {
+  if (deployment.secretsJsonContents) {
     requiredActions[secretsAction] = false;
   }
 

--- a/checks/policy-json-valid.js
+++ b/checks/policy-json-valid.js
@@ -47,15 +47,15 @@ const secretArn = /arn:(?<partition>[\w\*\-]*):secretsmanager:(?<region>[\w-]*):
  */
 async function policyJsonIsValid(deployment) {
   // policy.json is not required
-  if (!deployment.policyContents) {
+  if (!deployment.policyJsonContents) {
     core.info(`No policy.json present, skipping - ${deployment.serviceName}`);
     return [];
   }
-  core.info(`policy.json is valid - ${deployment.policyPath}`);
+  core.info(`policy.json is valid - ${deployment.policyJsonPath}`);
 
   let { results, document } = validateGenericIamPolicy(
-    deployment.policyContents.join("\n"),
-    deployment.policyPath
+    deployment.policyJsonContents.join("\n"),
+    deployment.policyJsonPath
   );
 
   if (!document) {
@@ -175,8 +175,8 @@ async function policyJsonIsValid(deployment) {
     }
     return {
       title,
-      path: deployment.policyPath,
-      line: getLineWithinObject(deployment.policyContents, searchBlock, regex),
+      path: deployment.policyJsonPath,
+      line: getLineWithinObject(deployment.policyJsonContents, searchBlock, regex),
       level: 'warning',
       problems: [
         problem
@@ -259,7 +259,7 @@ async function policyJsonIsValid(deployment) {
     ) {
       const result = {
         title: "Policy is missing required secrets",
-        path: deployment.policyPath,
+        path: deployment.policyJsonPath,
         problems: [],
         line: 0,
         level: "failure",
@@ -285,7 +285,7 @@ async function policyJsonIsValid(deployment) {
       };
 
       // This lets us indent more correctly
-      const { indent } = detectIndentation(deployment.policyContents);
+      const { indent } = detectIndentation(deployment.policyJsonContents);
       const newPolicy = Object.assign({}, document);
       newPolicy.Statement = statementBlock.concat([newStatementBlock]);
       const newPolicyLines = JSON.stringify(newPolicy, null, indent).split("\n");
@@ -295,13 +295,13 @@ async function policyJsonIsValid(deployment) {
         .join("\n")}`;
 
       const { end: lineToAnnotate } = getLinesForJSON(
-        deployment.policyContents,
+        deployment.policyJsonContents,
         statementBlock[statementBlock.length - 1]
       );
 
       result.line = lineToAnnotate;
 
-      const oldLine = deployment.policyContents[lineToAnnotate - 1];
+      const oldLine = deployment.policyJsonContents[lineToAnnotate - 1];
       let newLine = oldLine;
       if (!oldLine.endsWith(",")) {
         newLine += ",";
@@ -322,7 +322,7 @@ async function policyJsonIsValid(deployment) {
   ) {
     const result = {
       title: "Policy is missing required actions",
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: [],
       line: 0,
       level: "failure",
@@ -347,13 +347,13 @@ function maybeFixCapitalization({
   lineNumber,
   regex,
   correct,
-  policyPath,
+  policyJsonPath,
   title = "Capitalize this key",
 }) {
   if (regex.test(line)) {
     return {
       title: "Statement must be capitalized",
-      path: policyPath,
+      path: policyJsonPath,
       problems: [suggest(title, line.replace(regex, correct))],
       line: lineNumber,
       level: "failure",
@@ -416,49 +416,49 @@ function validateGenericIamPolicy(file, filePath) {
         lineNumber,
         regex: lowerId,
         correct: '"Id"',
-        policyPath: filePath,
+        policyJsonPath: filePath,
       },
       {
         line,
         lineNumber,
         regex: lowerVersion,
         correct: '"Version"',
-        policyPath: filePath,
+        policyJsonPath: filePath,
       },
       {
         line,
         lineNumber,
         regex: lowerStatement,
         correct: '"Statement"',
-        policyPath: filePath,
+        policyJsonPath: filePath,
       },
       {
         line,
         lineNumber,
         regex: lowerSid,
         correct: '"Sid"',
-        policyPath: filePath,
+        policyJsonPath: filePath,
       },
       {
         line,
         lineNumber,
         regex: lowerEffect,
         correct: '"Effect"',
-        policyPath: filePath,
+        policyJsonPath: filePath,
       },
       {
         line,
         lineNumber,
         regex: lowerPrincipal,
         correct: '"Principal"',
-        policyPath: filePath,
+        policyJsonPath: filePath,
       },
       {
         line,
         lineNumber,
         regex: wrongPrinciple,
         correct: '"Principal"',
-        policyPath: filePath,
+        policyJsonPath: filePath,
         title: "Wrong spelling of Principal",
       },
       {
@@ -466,35 +466,35 @@ function validateGenericIamPolicy(file, filePath) {
         lineNumber,
         regex: lowerAction,
         correct: '"Action"',
-        policyPath: filePath,
+        policyJsonPath: filePath,
       },
       {
         line,
         lineNumber,
         regex: lowerNotAction,
         correct: '"NotAction"',
-        policyPath: filePath,
+        policyJsonPath: filePath,
       },
       {
         line,
         lineNumber,
         regex: lowerResource,
         correct: '"Resource"',
-        policyPath: filePath,
+        policyJsonPath: filePath,
       },
       {
         line,
         lineNumber,
         regex: lowerNotResource,
         correct: '"NotResource"',
-        policyPath: filePath,
+        policyJsonPath: filePath,
       },
       {
         line,
         lineNumber,
         regex: lowerCondition,
         correct: '"Condition"',
-        policyPath: filePath,
+        policyJsonPath: filePath,
       },
     ]
       .map(maybeFixCapitalization)

--- a/checks/policy-json-valid.js
+++ b/checks/policy-json-valid.js
@@ -48,7 +48,7 @@ const secretArn = /arn:(?<partition>[\w\*\-]*):secretsmanager:(?<region>[\w-]*):
 async function policyJsonIsValid(deployment) {
   // policy.json is not required
   if (!deployment.policyContents) {
-    core.info(`No policy.json present, skipping - ${deployment.ordersPath}`);
+    core.info(`No policy.json present, skipping - ${deployment.serviceName}`);
     return [];
   }
   core.info(`policy.json is valid - ${deployment.policyPath}`);

--- a/checks/policy-json-valid.js
+++ b/checks/policy-json-valid.js
@@ -265,6 +265,12 @@ async function policyJsonIsValid(deployment) {
         level: "failure",
       };
 
+      function _getSids() {
+        return statementBlock
+          .map(statement => statement.Sid)
+          .filter(sid => sid)
+      }
+
       Object.keys(requiredSecrets)
         .filter((key) => !requiredSecrets[key])
         .forEach((key) =>
@@ -273,14 +279,22 @@ async function policyJsonIsValid(deployment) {
           )
         );
 
+      // Sids must be unique within a policy
+      let Sid = "AllowRequiredSecrets";
+      let i = 0;
+      const allSids = _getSids();
+      while(allSids.includes(Sid)) {
+        i += 1;
+        Sid = `AllowRequiredSecrets${i}`;
+      }
+
       const newStatementBlock = {
-        Sid: "AllowRequiredSecrets",
+        Sid,
         Effect: "Allow",
         Action: secretsAction,
         Resource: Array.from(new Set(
           Object.keys(requiredSecrets)
             .filter((s) => !requiredSecrets[s])
-            // .map(_getSimpleSecret)
           ))
       };
 

--- a/checks/secrets-in-orders.js
+++ b/checks/secrets-in-orders.js
@@ -120,12 +120,12 @@ async function secretsInOrders(deployment, context, inputs) {
     if (secretsToAdd.length > 0) {
       const result = {
         title: "Missing Secrets in secrets.json",
-        path: deployment.secretsPath,
+        path: deployment.secretsJsonPath,
         problems: [],
         level: "failure",
       };
 
-      const { indent } = detectIndentation(deployment.secretsContents);
+      const { indent } = detectIndentation(deployment.secretsJsonContents);
 
       // This lets us indent more correctly
       const newSecretsJson = deployment.secretsJson.concat(secretsToAdd);
@@ -141,13 +141,13 @@ async function secretsInOrders(deployment, context, inputs) {
       });
 
       const { end: lineToAnnotate } = getLinesForJSON(
-        deployment.secretsContents,
+        deployment.secretsJsonContents,
         deployment.secretsJson[deployment.secretsJson.length - 1]
       );
 
       result.line = lineToAnnotate;
 
-      const oldLine = deployment.secretsContents[lineToAnnotate - 1];
+      const oldLine = deployment.secretsJsonContents[lineToAnnotate - 1];
       let newLine = oldLine;
       if (!oldLine.endsWith(",")) {
         newLine += ",";

--- a/checks/secrets-in-orders.js
+++ b/checks/secrets-in-orders.js
@@ -23,12 +23,16 @@ const removeLineSuggestion = "Remove this line\n```suggestion\n```";
  * @returns {Array<Result>}
  */
 async function secretsInOrders(deployment, context, inputs) {
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
   core.info(`Secrets in Orders File - ${deployment.ordersPath}`);
   const { awsAccount, secretsPrefix, awsRegion, awsPartition } = inputs;
   const results = [];
   const secretsJson = [];
   const { owner, repo, branch } = getOwnerRepoBranch(context);
-  const secretsJsonPath = path.join(path.dirname(deployment.ordersPath), "secrets.json");
+  const secretsJsonPath = path.join(deployment.serviceName, "secrets.json");
 
   deployment.ordersContents
     .map((line, i) => {

--- a/checks/secrets-json-valid.js
+++ b/checks/secrets-json-valid.js
@@ -15,7 +15,7 @@ async function secretsJsonIsValid(deployment) {
 
   // secrets.json is not required
   if (!deployment.secretsContents) {
-    core.info(`No secrets.json present, skipping - ${deployment.ordersPath}`);
+    core.info(`No secrets.json present, skipping - ${deployment.serviceName}`);
     return results;
   }
 

--- a/checks/secrets-json-valid.js
+++ b/checks/secrets-json-valid.js
@@ -14,24 +14,24 @@ async function secretsJsonIsValid(deployment) {
   const results = [];
 
   // secrets.json is not required
-  if (!deployment.secretsContents) {
+  if (!deployment.secretsJsonContents) {
     core.info(`No secrets.json present, skipping - ${deployment.serviceName}`);
     return results;
   }
 
-  core.info(`secrets.json is valid - ${deployment.secretsPath}`);
+  core.info(`secrets.json is valid - ${deployment.secretsJsonPath}`);
 
   // secrets.json must be valid json
   let secretsJson;
   try {
-    secretsJson = JSON.parse(deployment.secretsContents.join("\n"));
+    secretsJson = JSON.parse(deployment.secretsJsonContents.join("\n"));
   } catch (e) {
     return [
       {
         title: "secrets.json is not valid JSON",
-        path: deployment.secretsPath,
+        path: deployment.secretsJsonPath,
         problems: [
-          `An error was encountered while trying to JSON parse ${deployment.secretsPath}`,
+          `An error was encountered while trying to JSON parse ${deployment.secretsJsonPath}`,
         ],
         line: 0,
         level: "failure",
@@ -44,7 +44,7 @@ async function secretsJsonIsValid(deployment) {
     return [
       {
         title: `Invalid secrets.json`,
-        path: deployment.secretsPath,
+        path: deployment.secretsJsonPath,
         problems: [
           "secrets.json must be an array of objects like `[{ name, valueFrom }]`",
         ],
@@ -59,7 +59,7 @@ async function secretsJsonIsValid(deployment) {
       return [
         {
           title: `Invalid secrets.json`,
-          path: deployment.secretsPath,
+          path: deployment.secretsJsonPath,
           problems: [
             "secrets.json must be an array of objects like `[{ name, valueFrom }]`",
           ],
@@ -73,10 +73,10 @@ async function secretsJsonIsValid(deployment) {
       title: "Invalid Secret Structure",
       problems: [],
       level: "failure",
-      path: deployment.secretsPath,
+      path: deployment.secretsJsonPath,
     };
 
-    const lines = getLinesForJSON(deployment.secretsContents, secret);
+    const lines = getLinesForJSON(deployment.secretsJsonContents, secret);
     if (lines.start === lines.end) {
       result.line = lines.start;
     } else {
@@ -95,19 +95,19 @@ async function secretsJsonIsValid(deployment) {
       if (wrongCaseForName) {
         const regex = new RegExp(`"${key}":`);
         const lineNumber = getLineWithinObject(
-          deployment.secretsContents,
+          deployment.secretsJsonContents,
           secret,
           regex
         );
         results.push({
           title: "Incorrect Casing",
           level: "failure",
-          path: deployment.secretsPath,
+          path: deployment.secretsJsonPath,
           line: lineNumber,
           problems: [
             suggest(
               "Lowercase this key:",
-              deployment.secretsContents[lineNumber - 1].replace(regex, '"name":')
+              deployment.secretsJsonContents[lineNumber - 1].replace(regex, '"name":')
             ),
           ],
         });
@@ -115,19 +115,19 @@ async function secretsJsonIsValid(deployment) {
       } else if (wrongCaseForValueFrom) {
         const regex = new RegExp(`"${key}":`);
         const lineNumber = getLineWithinObject(
-          deployment.secretsContents,
+          deployment.secretsJsonContents,
           secret,
           regex
         );
         results.push({
           title: "Incorrect Casing",
           level: "failure",
-          path: deployment.secretsPath,
+          path: deployment.secretsJsonPath,
           line: lineNumber,
           problems: [
             suggest(
               "Lowercase this key:",
-              deployment.secretsContents[lineNumber - 1].replace(
+              deployment.secretsJsonContents[lineNumber - 1].replace(
                 regex,
                 '"valueFrom":'
               )

--- a/checks/security-mode.js
+++ b/checks/security-mode.js
@@ -10,6 +10,11 @@ const { isAJob } = require('../util');
  * @returns {Array<Result>}
  */
 async function templateCheck(deployment, context) {
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
+
   if (isAJob(deployment.ordersContents)) {
     core.info('Jobs do not require a security mode, skipping.');
     return [];

--- a/checks/service-name.js
+++ b/checks/service-name.js
@@ -11,9 +11,14 @@ const validCharacters = /^[a-z][a-z0-9-]*$/;
  * @returns {Array<Result>}
  */
 async function validateServiceName(deployment) {
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
+
   core.info(`Valid Service Name - ${deployment.ordersPath}`);
 
-  const serviceName = path.dirname(deployment.ordersPath);
+  const { serviceName } = deployment;
 
   const problems = [];
 

--- a/checks/template.js
+++ b/checks/template.js
@@ -19,7 +19,7 @@ async function templateCheck(deployment, context, inputs) {
     problems: ['This code sucks'],
     line: lineNumber,
     level: 'failure' // must be "failure", "warning", "notice", or "success"
-    [path]: deployment.secretsPath // This defaults to the deployment path, but you can override for different files.
+    [path]: deployment.secretsJsonPath // This defaults to the deployment path, but you can override for different files.
    }
    */
 

--- a/checks/valid-bash-substitution.js
+++ b/checks/valid-bash-substitution.js
@@ -10,6 +10,10 @@ const singleQuoteSubsitution = /export \w+='.*\$({|)\w+(}|).*'/;
  * @returns {Array<Result>}
  */
 async function validBashSubsitutions(deployment) {
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
   core.info(`Valid Bash Substitution - ${deployment.ordersPath}`);
   const results = [];
 

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function _camelCaseFileName(filename) {
  */
 async function getContents(serviceName) {
   const result = { serviceName };
-  filesToCheck.forEach(async (filename) => {
+  for (let filename of filesToCheck) {
     const filepath = path.join(serviceName, filename);
     try {
       await fs.stat(filepath);
@@ -42,8 +42,8 @@ async function getContents(serviceName) {
     } catch (e) {
       // No particular file is required in order to run the check suite
     }
-  });
-  
+  }
+    
   return result;
 }
 

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ async function getContents(serviceName) {
       // No particular file is required in order to run the check suite
     }
   }
-    
+  console.log(result);  
   return result;
 }
 

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function _camelCaseFileName(filename) {
  */
 async function getContents(serviceName) {
   const result = { serviceName };
-  filesToCheck.forEach((filename) => {
+  filesToCheck.forEach(async (filename) => {
     const filepath = path.join(serviceName, filename);
     try {
       await fs.stat(filepath);

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ async function getContents(serviceName) {
     const filepath = path.join(serviceName, filename);
     try {
       await fs.stat(filepath);
-      const contents = await fs.readFile(filePath, "utf8");
+      const contents = await fs.readFile(filepath, "utf8");
       result[`${_camelCaseFileName(filename)}Path`] = filepath;
       result[`${_camelCaseFileName(filename)}Contents`] = contents.split('\n');
     } catch (e) {

--- a/index.js
+++ b/index.js
@@ -43,7 +43,6 @@ async function getContents(serviceName) {
       // No particular file is required in order to run the check suite
     }
   }
-  console.log(result);  
   return result;
 }
 

--- a/test/deployment-line.js
+++ b/test/deployment-line.js
@@ -5,6 +5,7 @@ describe("Deployment Line Check", () => {
   it("works with a valid deployment line", async () => {
     // works with autodeploy
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["autodeploy git@github.com:glg/price-service.git#main"],
     };
@@ -15,6 +16,7 @@ describe("Deployment Line Check", () => {
 
     // works with dockerdeploy
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["dockerdeploy github/glg/price-service/main:latest"],
     };
@@ -25,6 +27,7 @@ describe("Deployment Line Check", () => {
 
     // works with jobdeploy
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["jobdeploy github/glg/price-service/main:latest"],
     };
@@ -36,6 +39,7 @@ describe("Deployment Line Check", () => {
 
   it("rejects an improperly formatted dockerdeploy line", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["dockerdeploy git@github:glg/streamliner.git:latest"],
     };
@@ -50,6 +54,7 @@ describe("Deployment Line Check", () => {
 
   it("rejects an improperly formatted jobdeploy line", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["jobdeploy git@github:glg/streamliner.git:latest"],
     };
@@ -64,6 +69,7 @@ describe("Deployment Line Check", () => {
 
   it("rejects an improperly formatted autodeploy line", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["autodeploy git@github/glg/streamliner.git#main"],
     };
@@ -78,6 +84,7 @@ describe("Deployment Line Check", () => {
 
   it("requires either a dockerdeploy or an autodeploy line", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ['export HEALTHCHECK="/diagnostic"'],
     };
@@ -93,6 +100,7 @@ describe("Deployment Line Check", () => {
   it("rejects repository names with invalid characters", async () => {
     // works with autodeploy
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["autodeploy git@github.com:glg/PriceService.git#main"],
     };
@@ -106,6 +114,7 @@ describe("Deployment Line Check", () => {
 
     // works with dockerdeploy
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["dockerdeploy github/glg/PriceService/main:latest"],
     };
@@ -121,6 +130,7 @@ describe("Deployment Line Check", () => {
   it("rejects branch names with invalid characters", async () => {
     // works with autodeploy
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [
         "autodeploy git@github.com:glg/price-service.git#Wrong_Branch!",
@@ -136,8 +146,11 @@ describe("Deployment Line Check", () => {
 
     // works with dockerdeploy
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
-      ordersContents: ["dockerdeploy github/glg/price-service/Wrong_Branch!:latest"],
+      ordersContents: [
+        "dockerdeploy github/glg/price-service/Wrong_Branch!:latest",
+      ],
     };
 
     results = await deploymentLineCheck(deployment);
@@ -151,8 +164,11 @@ describe("Deployment Line Check", () => {
   it("rejects branch names that contain --", async () => {
     // works with autodeploy
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
-      ordersContents: ["autodeploy git@github.com:glg/price-service.git#too--many"],
+      ordersContents: [
+        "autodeploy git@github.com:glg/price-service.git#too--many",
+      ],
     };
 
     let results = await deploymentLineCheck(deployment);
@@ -164,8 +180,11 @@ describe("Deployment Line Check", () => {
 
     // works with dockerdeploy
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
-      ordersContents: ["dockerdeploy github/glg/price-service/too--many:latest"],
+      ordersContents: [
+        "dockerdeploy github/glg/price-service/too--many:latest",
+      ],
     };
 
     results = await deploymentLineCheck(deployment);

--- a/test/healthcheck.js
+++ b/test/healthcheck.js
@@ -4,6 +4,7 @@ const healthcheckCheck = require("../checks/healthcheck");
 describe("Healthcheck Check", () => {
   it("works with a valid healthcheck", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export HEALTHCHECK=/diagnostic"],
     };
@@ -15,6 +16,7 @@ describe("Healthcheck Check", () => {
 
   it("Requires the presence of a healthcheck", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export NOT_A_HEALTHCHECK=nothing"],
     };
@@ -30,6 +32,7 @@ describe("Healthcheck Check", () => {
   it("rejects healthchecks at /", async () => {
     // works with a bare /
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export HEALTHCHECK=/"],
     };
@@ -43,6 +46,7 @@ describe("Healthcheck Check", () => {
 
     // works with '/'
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export HEALTHCHECK='/'"],
     };
@@ -56,6 +60,7 @@ describe("Healthcheck Check", () => {
 
     // works with "/"
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ['export HEALTHCHECK="/"'],
     };
@@ -71,6 +76,7 @@ describe("Healthcheck Check", () => {
   it("rejects an empty healthcheck", async () => {
     // works with unset variable
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export HEALTHCHECK="],
     };
@@ -84,6 +90,7 @@ describe("Healthcheck Check", () => {
 
     // works with ""
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ['export HEALTHCHECK=""'],
     };
@@ -97,6 +104,7 @@ describe("Healthcheck Check", () => {
 
     // works with ''
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export HEALTHCHECK=''"],
     };

--- a/test/https-only.js
+++ b/test/https-only.js
@@ -4,6 +4,7 @@ const httpsOnly = require("../checks/https-only");
 describe("HTTPS Only Check", () => {
   it("rejects exported insecure glg domains", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [
         "export SEARCH=http://search.glgresearch.com/mosaic",
@@ -37,6 +38,7 @@ export MORE='https://services.glgresearch.com/streamliner'
 
   it("accepts secure glg domains", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [
         "export SEARCH=https://search.glgresearch.com/mosaic",

--- a/test/jwt-access-flags.js
+++ b/test/jwt-access-flags.js
@@ -4,6 +4,7 @@ const jwtAccessFlags = require("../checks/jwt-access-flags");
 describe("Valid bitwise operations in JWT_ACCESS_FLAGS", () => {
   it("allows orders with no JWT_ACCESS_FLAGS declaration", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
     };
@@ -14,6 +15,7 @@ describe("Valid bitwise operations in JWT_ACCESS_FLAGS", () => {
 
   it("allows orders where JWT_ACCESS_FLAGS uses a | to combine roles", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [
         "export JWT_ACCESS_FLAGS=$(($JWT_ROLE_GLG_USER | $JWT_ROLE_GLG_CLIENT))",
@@ -26,6 +28,7 @@ describe("Valid bitwise operations in JWT_ACCESS_FLAGS", () => {
 
   it("rejects orders where JWT_ACCESS_FLAGS uses a + to combine roles", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [
         "export JWT_ACCESS_FLAGS=$(($JWT_ROLE_GLG_USER + $JWT_ROLE_GLG_CLIENT))",

--- a/test/no-carriage-return.js
+++ b/test/no-carriage-return.js
@@ -4,6 +4,7 @@ const noCarriageReturn = require("../checks/no-carriage-return");
 describe("No Carriage Return", () => {
   it("accepts a file with no carriage returns", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export VAR=value", "# A comment", "export VARZ=valuez"],
     };
@@ -14,6 +15,7 @@ describe("No Carriage Return", () => {
 
   it("Rejects Orders file with CRLF", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [
         "export VAR=value\r",
@@ -49,6 +51,7 @@ describe("No Carriage Return", () => {
     ]`;
 
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export VAR=value", "# A comment", "export VARZ=valuez"],
       secretsPath: "streamliner/secrets.json",
@@ -95,6 +98,7 @@ describe("No Carriage Return", () => {
     ).replace(/\n/g, "\r\n");
 
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export VAR=value", "# A comment", "export VARZ=valuez"],
       policyPath: "streamliner/policy.json",

--- a/test/no-carriage-return.js
+++ b/test/no-carriage-return.js
@@ -54,8 +54,8 @@ describe("No Carriage Return", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export VAR=value", "# A comment", "export VARZ=valuez"],
-      secretsPath: "streamliner/secrets.json",
-      secretsContents: secretsJson.split("\n"),
+      secretsJsonPath: "streamliner/secrets.json",
+      secretsJsonContents: secretsJson.split("\n"),
     };
 
     const results = await noCarriageReturn(deployment);
@@ -63,12 +63,12 @@ describe("No Carriage Return", () => {
     expect(results[0]).to.deep.equal({
       title: "No Carriage Return Characters",
       problems: [
-        `\`${deployment.secretsPath}\` contains invalid newline characters.`,
+        `\`${deployment.secretsJsonPath}\` contains invalid newline characters.`,
         "You must use Unix-type newlines (`LF`). Windows-type newlines (`CRLF`) are not permitted.",
       ],
       line: 0,
       level: "failure",
-      path: deployment.secretsPath,
+      path: deployment.secretsJsonPath,
     });
   });
 

--- a/test/no-carriage-return.js
+++ b/test/no-carriage-return.js
@@ -101,8 +101,8 @@ describe("No Carriage Return", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export VAR=value", "# A comment", "export VARZ=valuez"],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
     };
 
     const results = await noCarriageReturn(deployment);
@@ -110,12 +110,12 @@ describe("No Carriage Return", () => {
     expect(results[0]).to.deep.equal({
       title: "No Carriage Return Characters",
       problems: [
-        `\`${deployment.policyPath}\` contains invalid newline characters.`,
+        `\`${deployment.policyJsonPath}\` contains invalid newline characters.`,
         "You must use Unix-type newlines (`LF`). Windows-type newlines (`CRLF`) are not permitted.",
       ],
       line: 0,
       level: "failure",
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
     });
   });
 });

--- a/test/no-debug-in-prod.js
+++ b/test/no-debug-in-prod.js
@@ -4,7 +4,8 @@ const noDebugInProd = require('../checks/no-debug-in-prod');
 describe('No Debug In Prod', async () => {
   it('accepts orders file with no known debug flags', async () => {
     const deployment = {
-      path: 'streamliner/orders',
+      serviceName: "streamliner",
+      ordersPath: 'streamliner/orders',
       ordersContents: [
         'export HEALTHCHECK=/diagnostic'
       ]
@@ -16,7 +17,8 @@ describe('No Debug In Prod', async () => {
 
   it('warns about known debug flags', async () => {
     const deployment = {
-      path: 'streamliner/orders',
+      serviceName: "streamliner",
+      ordersPath: 'streamliner/orders',
       ordersContents: [
         'export ENABLE_DEBUG="true"',
         'export DEBUG=know*',

--- a/test/no-duplicate-exports.js
+++ b/test/no-duplicate-exports.js
@@ -4,6 +4,7 @@ const noDupes = require("../checks/no-duplicate-exports");
 describe("No Duplicate Exports Check", () => {
   it("allows orders with no duplicate exports", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [
         "export THREE=something",
@@ -19,6 +20,7 @@ describe("No Duplicate Exports Check", () => {
 
   it("rejects orders that contain duplicate exports", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [
         "export DUPED=something",

--- a/test/no-sourcing.js
+++ b/test/no-sourcing.js
@@ -4,6 +4,7 @@ const noSourcing = require("../checks/no-sourcing");
 describe("No Sourcing Check", () => {
   it("allows orders with no external sourcing", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
     };
@@ -14,6 +15,7 @@ describe("No Sourcing Check", () => {
 
   it("rejects orders that source another file", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["source /var/starphleet/headquarters/cookie-beta/orders"],
     };

--- a/test/no-spaces-in-exports.js
+++ b/test/no-spaces-in-exports.js
@@ -4,6 +4,7 @@ const noSpaces = require("../checks/no-spaces-in-exports");
 describe("No Spaces in Exports Check", () => {
   it("allows orders where all exports have proper spacing", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [
         "export HEALTHCHECK=/diagnostic",
@@ -18,6 +19,7 @@ describe("No Spaces in Exports Check", () => {
 
   it("rejects orders if they include exports with incorrect spacing", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [
         "export HEALTHCHECK =/diagnostic",

--- a/test/policy-json-valid.js
+++ b/test/policy-json-valid.js
@@ -701,7 +701,7 @@ describe("policy.json is valid", () => {
             Effect: "Allow",
             Action: "secretsmanager:GetSecretValue",
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret-??????",
           },
           {
             Effect: "Allow",
@@ -741,7 +741,7 @@ describe("policy.json is valid", () => {
       title: "Policy is missing required secrets",
       path: "streamliner/policy.json",
       problems: [
-        "Your secrets.json requests arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else, but your policy does not allow access.",
+        "Your secrets.json requests arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else-??????, but your policy does not allow access.",
         "Add the following statement block\n" +
           "```suggestion\n" +
           "    },\n" + 
@@ -750,7 +750,7 @@ describe("policy.json is valid", () => {
           '      "Effect": "Allow",\n' +
           '      "Action": "secretsmanager:GetSecretValue",\n' +
           '      "Resource": [\n' +
-          '        "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else"\n' +
+          '        "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else-??????"\n' +
           "      ]\n" +
           "    }\n" +
           "```",
@@ -767,7 +767,10 @@ describe("policy.json is valid", () => {
           {
             Effect: "Allow",
             Action: "secretsmanager:GetSecretValue",
-            Resource: "arn:aws:secretsmanager:us-east-1:868468680417:secret:*", // supports wildcards
+            Resource: [
+              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret-??????",
+              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else-??????"
+            ], // supports wildcards
           },
           {
             Effect: "Allow",

--- a/test/policy-json-valid.js
+++ b/test/policy-json-valid.js
@@ -8,6 +8,7 @@ const resourceFmtError = '"Resource" must be either a valid [ARN](https://docs.a
 describe("policy.json is valid", () => {
   it("skips if there is no policy.json", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
     };
@@ -41,6 +42,7 @@ describe("policy.json is valid", () => {
       2
     );
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -53,6 +55,7 @@ describe("policy.json is valid", () => {
 
   it("rejects policy.json that is not valid JSON", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -91,6 +94,7 @@ describe("policy.json is valid", () => {
       2
     );
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -133,6 +137,7 @@ describe("policy.json is valid", () => {
       2
     );
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -214,6 +219,7 @@ describe("policy.json is valid", () => {
       2
     );
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -256,6 +262,7 @@ describe("policy.json is valid", () => {
       2
     );
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -282,6 +289,7 @@ describe("policy.json is valid", () => {
       2
     );
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -329,6 +337,7 @@ describe("policy.json is valid", () => {
       2
     );
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -379,6 +388,7 @@ describe("policy.json is valid", () => {
       2
     );
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -427,6 +437,7 @@ describe("policy.json is valid", () => {
       2
     );
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -478,6 +489,7 @@ describe("policy.json is valid", () => {
     );
 
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -527,6 +539,7 @@ describe("policy.json is valid", () => {
       2
     );
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -578,6 +591,7 @@ describe("policy.json is valid", () => {
     );
 
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -627,6 +641,7 @@ describe("policy.json is valid", () => {
       2
     );
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -672,6 +687,7 @@ describe("policy.json is valid", () => {
       2
     );
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -717,6 +733,7 @@ describe("policy.json is valid", () => {
       2
     );
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -786,6 +803,7 @@ describe("policy.json is valid", () => {
       2
     );
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -832,6 +850,7 @@ describe("policy.json is valid", () => {
       2
     );
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",
@@ -902,6 +921,7 @@ describe("policy.json is valid", () => {
       2
     );
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       policyPath: "streamliner/policy.json",

--- a/test/policy-json-valid.js
+++ b/test/policy-json-valid.js
@@ -45,8 +45,8 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
     };
 
     const results = await policyJsonIsValid(deployment);
@@ -58,17 +58,17 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: ["not valid json"],
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: ["not valid json"],
     };
 
     const results = await policyJsonIsValid(deployment);
     expect(results.length).to.equal(1);
     expect(results[0]).to.deep.equal({
       title: "policy.json is not valid JSON",
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: [
-        `An error was encountered while trying to JSON parse ${deployment.policyPath}`,
+        `An error was encountered while trying to JSON parse ${deployment.policyJsonPath}`,
       ],
       line: 0,
       level: "failure",
@@ -97,15 +97,15 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
     };
 
     const results = await policyJsonIsValid(deployment);
     expect(results.length).to.equal(1);
     expect(results[0]).to.deep.equal({
       title: `Invalid policy.json`,
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: ["policy.json must be a valid AWS IAM Policy"],
       line: 1,
       level: "failure",
@@ -140,8 +140,8 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
     };
 
     const results = await policyJsonIsValid(deployment);
@@ -151,7 +151,7 @@ describe("policy.json is valid", () => {
 
     expect(version).to.deep.equal({
       title: "Statement must be capitalized",
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: [suggest("Capitalize this key", '  "Version": "2012-10-17",')],
       line: 2,
       level: "failure",
@@ -159,7 +159,7 @@ describe("policy.json is valid", () => {
 
     expect(statement).to.deep.equal({
       title: "Statement must be capitalized",
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: [suggest("Capitalize this key", '  "Statement": [')],
       line: 3,
       level: "failure",
@@ -167,7 +167,7 @@ describe("policy.json is valid", () => {
 
     expect(effect).to.deep.equal({
       title: "Statement must be capitalized",
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: [suggest("Capitalize this key", '      "Effect": "Allow",')],
       line: 5,
       level: "failure",
@@ -175,7 +175,7 @@ describe("policy.json is valid", () => {
 
     expect(action).to.deep.equal({
       title: "Statement must be capitalized",
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: [suggest("Capitalize this key", '      "Action": [')],
       line: 6,
       level: "failure",
@@ -183,7 +183,7 @@ describe("policy.json is valid", () => {
 
     expect(resource).to.deep.equal({
       title: "Statement must be capitalized",
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: [
         suggest(
           "Capitalize this key",
@@ -222,15 +222,15 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
     };
 
     const results = await policyJsonIsValid(deployment);
     expect(results.length).to.equal(1);
     expect(results[0]).to.deep.equal({
       title: 'Policy must have a "Version" field',
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: ['"Version" is a required field.'],
       line: 0,
       level: "failure",
@@ -265,15 +265,15 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
     };
 
     const results = await policyJsonIsValid(deployment);
     expect(results.length).to.equal(1);
     expect(results[0]).to.deep.equal({
       title: "Invalid Version",
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: ["Version must be one of: 2008-10-17, 2012-10-17"],
       line: 2,
       level: "failure",
@@ -292,15 +292,15 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
     };
 
     const results = await policyJsonIsValid(deployment);
     expect(results.length).to.equal(1);
     expect(results[0]).to.deep.equal({
       title: 'Policy must have a "Statement" block.',
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: ['"Statement" is a required field'],
       line: 0,
       level: "failure",
@@ -340,8 +340,8 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
     };
 
     const results = await policyJsonIsValid(deployment);
@@ -391,8 +391,8 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
     };
 
     const results = await policyJsonIsValid(deployment);
@@ -440,8 +440,8 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
     };
 
     let results = await policyJsonIsValid(deployment);
@@ -492,8 +492,8 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
     };
 
     results = (await policyJsonIsValid(deployment)).filter(({ level }) => level === 'failure');
@@ -542,15 +542,15 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
     };
 
     let results = await policyJsonIsValid(deployment);
     expect(results.length).to.equal(1);
     expect(results[0]).to.deep.equal({
       title: 'Invalid value for "Resource"',
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: [
         resourceFmtError,
       ],
@@ -594,15 +594,15 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
     };
 
     results = (await policyJsonIsValid(deployment)).filter(({ level }) => level === 'failure');
     expect(results.length).to.equal(1);
     expect(results[0]).to.deep.equal({
       title: 'Invalid value for "Resource"',
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: [
         resourceFmtError,
       ],
@@ -644,8 +644,8 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
     };
 
     let results = await policyJsonIsValid(deployment);
@@ -690,8 +690,8 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
       secretsContents: [], // indicates presence of a secrets.json
     };
 
@@ -736,8 +736,8 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
       secretsContents: [], // indicates presence of a secrets.json
       secretsJson: [
         {
@@ -806,8 +806,8 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
       secretsContents: [], // indicates presence of a secrets.json
       secretsJson: [
         {
@@ -853,8 +853,8 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
       secretsContents: [], // indicates presence of a secrets.json
       secretsJson: [
         {
@@ -877,7 +877,7 @@ describe("policy.json is valid", () => {
       title: 'Broad Permissions',
       level: 'warning',
       line: 12,
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: [problem]
     });
 
@@ -885,7 +885,7 @@ describe("policy.json is valid", () => {
       title: 'Broad Permissions',
       level: 'warning',
       line: 13,
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: [problem]
     });
 
@@ -893,7 +893,7 @@ describe("policy.json is valid", () => {
       title: 'Broad Permissions',
       level: 'warning',
       line: 15,
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: [problem]
     });
   });
@@ -924,8 +924,8 @@ describe("policy.json is valid", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      policyPath: "streamliner/policy.json",
-      policyContents: policyJson.split("\n"),
+      policyJsonPath: "streamliner/policy.json",
+      policyJsonContents: policyJson.split("\n"),
       secretsContents: [], // indicates presence of a secrets.json
       secretsJson: [
         {
@@ -948,7 +948,7 @@ describe("policy.json is valid", () => {
       title: 'Delete Access',
       level: 'warning',
       line: 12,
-      path: deployment.policyPath,
+      path: deployment.policyJsonPath,
       problems: [problem]
     });
   });

--- a/test/policy-json-valid.js
+++ b/test/policy-json-valid.js
@@ -692,7 +692,7 @@ describe("policy.json is valid", () => {
       ordersContents: [],
       policyJsonPath: "streamliner/policy.json",
       policyJsonContents: policyJson.split("\n"),
-      secretsContents: [], // indicates presence of a secrets.json
+      secretsJsonContents: [], // indicates presence of a secrets.json
     };
 
     let results = (await policyJsonIsValid(deployment)).filter(({ level }) => level === 'failure');
@@ -738,7 +738,7 @@ describe("policy.json is valid", () => {
       ordersContents: [],
       policyJsonPath: "streamliner/policy.json",
       policyJsonContents: policyJson.split("\n"),
-      secretsContents: [], // indicates presence of a secrets.json
+      secretsJsonContents: [], // indicates presence of a secrets.json
       secretsJson: [
         {
           name: "MY_SECRET",
@@ -808,7 +808,7 @@ describe("policy.json is valid", () => {
       ordersContents: [],
       policyJsonPath: "streamliner/policy.json",
       policyJsonContents: policyJson.split("\n"),
-      secretsContents: [], // indicates presence of a secrets.json
+      secretsJsonContents: [], // indicates presence of a secrets.json
       secretsJson: [
         {
           name: "MY_SECRET",
@@ -855,7 +855,7 @@ describe("policy.json is valid", () => {
       ordersContents: [],
       policyJsonPath: "streamliner/policy.json",
       policyJsonContents: policyJson.split("\n"),
-      secretsContents: [], // indicates presence of a secrets.json
+      secretsJsonContents: [], // indicates presence of a secrets.json
       secretsJson: [
         {
           name: "MY_SECRET",
@@ -926,7 +926,7 @@ describe("policy.json is valid", () => {
       ordersContents: [],
       policyJsonPath: "streamliner/policy.json",
       policyJsonContents: policyJson.split("\n"),
-      secretsContents: [], // indicates presence of a secrets.json
+      secretsJsonContents: [], // indicates presence of a secrets.json
       secretsJson: [
         {
           name: "MY_SECRET",

--- a/test/secrets-in-orders.js
+++ b/test/secrets-in-orders.js
@@ -181,8 +181,8 @@ describe("Secrets in orders file", () => {
         "dockerdeploy github/glg/streamliner/master:latest",
       ],
       secretsJson,
-      secretsContents: JSON.stringify(secretsJson, null, 4).split("\n"),
-      secretsPath: "streamliner/secrets.json",
+      secretsJsonContents: JSON.stringify(secretsJson, null, 4).split("\n"),
+      secretsJsonPath: "streamliner/secrets.json",
     };
 
     const results = await secretsInOrders(deployment, context, inputs);

--- a/test/secrets-in-orders.js
+++ b/test/secrets-in-orders.js
@@ -34,6 +34,7 @@ const context = {
 describe("Secrets in orders file", () => {
   it("accepts an orders file with no use of secrets", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [
         "export SOMEVAR=notasecret",
@@ -47,6 +48,7 @@ describe("Secrets in orders file", () => {
 
   it("recommends creating a secrets.json if one is not present and there are secrets in the orders", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [
         "export SOMEVAR=notasecret",
@@ -167,6 +169,7 @@ describe("Secrets in orders file", () => {
       },
     ];
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [
         "export SOMEVAR=notasecret",

--- a/test/secrets-json-valid.js
+++ b/test/secrets-json-valid.js
@@ -33,8 +33,8 @@ describe("secrets.json is valid check", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      secretsPath: "streamliner/secrets.json",
-      secretsContents: secretsJson.split("\n"),
+      secretsJsonPath: "streamliner/secrets.json",
+      secretsJsonContents: secretsJson.split("\n"),
     };
 
     const results = await secretsJsonIsValid(deployment);
@@ -52,17 +52,17 @@ describe("secrets.json is valid check", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      secretsPath: "streamliner/secrets.json",
-      secretsContents: secretsJson.split("\n"),
+      secretsJsonPath: "streamliner/secrets.json",
+      secretsJsonContents: secretsJson.split("\n"),
     };
 
     const results = await secretsJsonIsValid(deployment);
     expect(results.length).to.equal(1);
     expect(results[0]).to.deep.equal({
       title: "secrets.json is not valid JSON",
-      path: deployment.secretsPath,
+      path: deployment.secretsJsonPath,
       problems: [
-        `An error was encountered while trying to JSON parse ${deployment.secretsPath}`,
+        `An error was encountered while trying to JSON parse ${deployment.secretsJsonPath}`,
       ],
       line: 0,
       level: "failure",
@@ -78,15 +78,15 @@ describe("secrets.json is valid check", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      secretsPath: "streamliner/secrets.json",
-      secretsContents: secretsJson.split("\n"),
+      secretsJsonPath: "streamliner/secrets.json",
+      secretsJsonContents: secretsJson.split("\n"),
     };
 
     const results = await secretsJsonIsValid(deployment);
     expect(results.length).to.equal(1);
     expect(results[0]).to.deep.equal({
       title: `Invalid secrets.json`,
-      path: deployment.secretsPath,
+      path: deployment.secretsJsonPath,
       problems: [
         "secrets.json must be an array of objects like `[{ name, valueFrom }]`",
       ],
@@ -112,15 +112,15 @@ describe("secrets.json is valid check", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      secretsPath: "streamliner/secrets.json",
-      secretsContents: secretsJson.split("\n"),
+      secretsJsonPath: "streamliner/secrets.json",
+      secretsJsonContents: secretsJson.split("\n"),
     };
 
     const results = await secretsJsonIsValid(deployment);
     expect(results.length).to.equal(1);
     expect(results[0]).to.deep.equal({
       title: `Invalid secrets.json`,
-      path: deployment.secretsPath,
+      path: deployment.secretsJsonPath,
       problems: [
         "secrets.json must be an array of objects like `[{ name, valueFrom }]`",
       ],
@@ -144,15 +144,15 @@ describe("secrets.json is valid check", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      secretsPath: "streamliner/secrets.json",
-      secretsContents: secretsJson.split("\n"),
+      secretsJsonPath: "streamliner/secrets.json",
+      secretsJsonContents: secretsJson.split("\n"),
     };
 
     const results = await secretsJsonIsValid(deployment);
     expect(results.length).to.equal(1);
     expect(results[0]).to.deep.equal({
       title: "Invalid Secret Structure",
-      path: deployment.secretsPath,
+      path: deployment.secretsJsonPath,
       problems: ["Each secret must be an object like { name, valueFrom }"],
       line: {
         start: 2,
@@ -179,15 +179,15 @@ describe("secrets.json is valid check", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      secretsPath: "streamliner/secrets.json",
-      secretsContents: secretsJson.split("\n"),
+      secretsJsonPath: "streamliner/secrets.json",
+      secretsJsonContents: secretsJson.split("\n"),
     };
 
     const results = await secretsJsonIsValid(deployment);
     expect(results.length).to.equal(1);
     expect(results[0]).to.deep.equal({
       title: "Invalid Secret Structure",
-      path: deployment.secretsPath,
+      path: deployment.secretsJsonPath,
       problems: [
         'Each secret must **only** contain the keys "name" and "valueFrom".',
       ],
@@ -215,15 +215,15 @@ describe("secrets.json is valid check", () => {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
-      secretsPath: "streamliner/secrets.json",
-      secretsContents: secretsJson.split("\n"),
+      secretsJsonPath: "streamliner/secrets.json",
+      secretsJsonContents: secretsJson.split("\n"),
     };
 
     const results = await secretsJsonIsValid(deployment);
     expect(results.length).to.equal(1);
     expect(results[0]).to.deep.equal({
       title: "Invalid Secret: OTHER_VALUE",
-      path: deployment.secretsPath,
+      path: deployment.secretsJsonPath,
       problems: ["Invalid secret ARN: dev/json_secret"],
       line: {
         start: 6,

--- a/test/secrets-json-valid.js
+++ b/test/secrets-json-valid.js
@@ -4,6 +4,7 @@ const secretsJsonIsValid = require("../checks/secrets-json-valid");
 describe("secrets.json is valid check", () => {
   it("skips when there is no secrets.json", async () => {
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
     };
@@ -29,6 +30,7 @@ describe("secrets.json is valid check", () => {
     ]`;
 
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       secretsPath: "streamliner/secrets.json",
@@ -47,6 +49,7 @@ describe("secrets.json is valid check", () => {
     const secretsJson = "invalid json";
 
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       secretsPath: "streamliner/secrets.json",
@@ -72,6 +75,7 @@ describe("secrets.json is valid check", () => {
     }`;
 
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       secretsPath: "streamliner/secrets.json",
@@ -105,6 +109,7 @@ describe("secrets.json is valid check", () => {
     ]`;
 
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       secretsPath: "streamliner/secrets.json",
@@ -136,6 +141,7 @@ describe("secrets.json is valid check", () => {
     ]`;
 
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       secretsPath: "streamliner/secrets.json",
@@ -170,6 +176,7 @@ describe("secrets.json is valid check", () => {
     ]`;
 
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       secretsPath: "streamliner/secrets.json",
@@ -205,6 +212,7 @@ describe("secrets.json is valid check", () => {
     ]`;
 
     const deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
       secretsPath: "streamliner/secrets.json",

--- a/test/security-mode.js
+++ b/test/security-mode.js
@@ -17,6 +17,7 @@ describe("Security Mode Check", () => {
 
     // Bare jwt
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export SECURITY_MODE=jwt"],
     };
@@ -26,6 +27,7 @@ describe("Security Mode Check", () => {
 
     // single quote jwt
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export SECURITY_MODE='jwt'"],
     };
@@ -35,6 +37,7 @@ describe("Security Mode Check", () => {
 
     // double quote jwt
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ['export SECURITY_MODE="jwt"'],
     };
@@ -44,6 +47,7 @@ describe("Security Mode Check", () => {
 
     // bare verfifiedSession
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export SECURITY_MODE=verifiedSession"],
     };
@@ -53,6 +57,7 @@ describe("Security Mode Check", () => {
 
     // single quote verifiedSession
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export SECURITY_MODE='verifiedSession'"],
     };
@@ -62,6 +67,7 @@ describe("Security Mode Check", () => {
 
     // double quote verifiedSession
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ['export SECURITY_MODE="verifiedSession"'],
     };
@@ -71,6 +77,7 @@ describe("Security Mode Check", () => {
 
     // And this fails as an invalid security mode
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export SECURITY_MODE=public"],
     };
@@ -98,6 +105,7 @@ describe("Security Mode Check", () => {
 
     // Bare public
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export SECURITY_MODE=public"],
     };
@@ -107,6 +115,7 @@ describe("Security Mode Check", () => {
 
     // single quote public
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export SECURITY_MODE='public'"],
     };
@@ -116,6 +125,7 @@ describe("Security Mode Check", () => {
 
     // double quote public
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ['export SECURITY_MODE="public"'],
     };
@@ -125,6 +135,7 @@ describe("Security Mode Check", () => {
 
     // And this fails as an invalid security mode
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export SECURITY_MODE=jwt"],
     };
@@ -152,6 +163,7 @@ describe("Security Mode Check", () => {
 
     // Bare public
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export SECURITY_MODE=public"],
     };
@@ -161,6 +173,7 @@ describe("Security Mode Check", () => {
 
     // single quote public
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export SECURITY_MODE='public'"],
     };
@@ -170,12 +183,17 @@ describe("Security Mode Check", () => {
 
     // double quote public
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ['export SECURITY_MODE="public"'],
     };
 
+    results = await securityMode(deployment, context);
+    expect(results.length).to.equal(0);
+
     // And this fails as an invalid security mode
     deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export SECURITY_MODE=jwt"],
     };
@@ -203,6 +221,7 @@ describe("Security Mode Check", () => {
 
     // Bare public
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [],
     };

--- a/test/service-name.js
+++ b/test/service-name.js
@@ -5,6 +5,7 @@ describe("Service Name Check", () => {
   it("works with a valid service name", async () => {
     const serviceName = "streamliner";
     const deployment = {
+      serviceName,
       ordersPath: `${serviceName}/orders`,
       ordersContents: [],
     };
@@ -18,6 +19,7 @@ describe("Service Name Check", () => {
     const serviceName =
       "thisservicenameismuchtoolongwayovertwentyeightcharacters";
     const deployment = {
+      serviceName,
       ordersPath: `${serviceName}/orders`,
       ordersContents: [],
     };
@@ -33,6 +35,7 @@ describe("Service Name Check", () => {
   it("rejects service names with invalid characters", async () => {
     const serviceName = "ThisServiceName_is_invalid";
     const deployment = {
+      serviceName,
       ordersPath: `${serviceName}/orders`,
       ordersContents: [],
     };
@@ -48,6 +51,7 @@ describe("Service Name Check", () => {
   it("rejects service names that contain --", async () => {
     const serviceName = "too--many--hyphens";
     const deployment = {
+      serviceName,
       ordersPath: `${serviceName}/orders`,
       ordersContents: [],
     };

--- a/test/valid-bash-subsitution.js
+++ b/test/valid-bash-subsitution.js
@@ -4,6 +4,7 @@ const validSubstitutionCheck = require("../checks/valid-bash-substitution");
 describe("Valid Bash Substitution Checker", async () => {
   it("accepts valid bash substitutions", async () => {
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [
         'export SOME_VAR="first-${SOME_OTHER_VALUE}-and-more-text"',
@@ -18,6 +19,7 @@ describe("Valid Bash Substitution Checker", async () => {
 
   it("rejects bash subsitutions contained in single quotes", async () => {
     let deployment = {
+      serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: [
         "export SOME_VAR='first-${SOME_OTHER_VALUE}-and-more-text'",

--- a/typedefs.js
+++ b/typedefs.js
@@ -249,8 +249,8 @@
  * serviceName: string,
  * ordersPath: (string|undefined),
  * ordersContents: (Array<string>|undefined),
- * secretsPath: (string|undefined),
- * secretsContents: (Array<string>|undefined),
+ * secretsJsonPath: (string|undefined),
+ * secretsJsonContents: (Array<string>|undefined),
  * policyJsonPath: (string|undefined),
  * policyJsonContents: (Array<string>|undefined)
  * }} Deployment

--- a/typedefs.js
+++ b/typedefs.js
@@ -251,8 +251,8 @@
  * ordersContents: (Array<string>|undefined),
  * secretsPath: (string|undefined),
  * secretsContents: (Array<string>|undefined),
- * policyPath: (string|undefined),
- * policyContents: (Array<string>|undefined)
+ * policyJsonPath: (string|undefined),
+ * policyJsonContents: (Array<string>|undefined)
  * }} Deployment
  */
 

--- a/typedefs.js
+++ b/typedefs.js
@@ -246,8 +246,9 @@
 
 /**
  * @typedef {{
- * ordersPath: string,
- * ordersContents: Array<string>,
+ * serviceName: string,
+ * ordersPath: (string|undefined),
+ * ordersContents: (Array<string>|undefined),
  * secretsPath: (string|undefined),
  * secretsContents: (Array<string>|undefined),
  * policyPath: (string|undefined),

--- a/util.js
+++ b/util.js
@@ -17,6 +17,7 @@ function getLinesForJSON(fileLines, jsonObj) {
   // Convert the object into a regex
   const regex = new RegExp(
     JSON.stringify(jsonObj)
+      .replace(/\?/g, "\\?")
       .replace(/\*/g, "\\*")
       .replace(/{/g, "{\\s*")
       .replace(/:"/g, ':\\s*"')


### PR DESCRIPTION
Previously, this has been only running checks if the orders file changed. Now, it will run checks when any of the important files change (orders, secrets.json, policy.json). This involved some minor changes to many checks to recognize the new optionality of orders file changes. This also incorporates changes related to how secret arns must be presented in IAM policy documents.