### PR TITLE
check for aws secrets

### DIFF
--- a/checks/index.js
+++ b/checks/index.js
@@ -16,6 +16,7 @@ module.exports = [
   require("./secrets-json-valid"),
   require("./secrets-in-orders"),
   require("./no-carriage-return"),
+  require('./no-aws-secrets'),
 
   /**
    *  This should probably always be last, because it verifies that the

--- a/checks/no-aws-secrets.js
+++ b/checks/no-aws-secrets.js
@@ -1,0 +1,63 @@
+require('../typedefs');
+const core = require("@actions/core");
+
+/**
+ * These regular expressions for finding aws access key id
+ * and secret access key are derived from this AWS blog:
+ * 
+ * https://aws.amazon.com/blogs/security/a-safer-way-to-distribute-aws-credentials-to-ec2/
+ */
+const AKID = /(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])/;
+const SAK = /(?<![A-Za-z0-9/+])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])/;
+const AKID_ENVVAR = /^export AWS_ACCESS_KEY_ID=/;
+const SAK_ENVVAR = /^export AWS_SECRET_ACCESS_KEY=/;
+
+/**
+ * Checks for AWS Access Key ID and AWS Secret Access Key
+ * @param {Deployment} deployment An object containing information about a deployment
+ * 
+ * @returns {Array<Result>}
+ */
+async function noAWSSecrets(deployment) {
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
+  core.info(`No AWS Secrets - ${deployment.ordersPath}`);
+  const results = [];
+
+  deployment.ordersContents.forEach((line, i) => {
+    const lineNumber = i + 1;
+
+    const result = {
+      title: 'Remove AWS Config from your orders file.',
+      line: lineNumber,
+      level: 'warning',
+      problems: [],
+      path: deployment.ordersPath
+    };
+
+    if (AKID_ENVVAR.test(line) || SAK_ENVVAR.test(line)) {
+      result.problems.push("You should rely on the container's role, which you can define with `policy.json`, rather than explicitly declaring AWS credentials.")
+    }
+
+    if (AKID.test(line)) {
+      result.level = "failure";
+      result.problems.push("Remove this Access Key ID from your orders file.");
+    }
+
+    if (SAK.test(line)) {
+      result.level = "failure";
+      result.problems.push("Remove this Secret Access Key from your orders file.");
+    }
+
+    if (result.problems.length > 0) {
+      results.push(result);
+    }
+    
+  });
+
+  return results;
+}
+
+module.exports = noAWSSecrets;

--- a/checks/template.js
+++ b/checks/template.js
@@ -10,6 +10,13 @@ const core = require("@actions/core");
  * @returns {Array<Result>}
  */
 async function templateCheck(deployment, context, inputs) {
+  /**
+   * You should check the existance of any file you're trying to check
+   */
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
   core.info(`Template Check - ${deployment.ordersPath}`);
   const results = [];
   /**

--- a/test/no-aws-secrets.js
+++ b/test/no-aws-secrets.js
@@ -1,0 +1,91 @@
+const { expect } = require('chai');
+const noAWSSecrets = require('../checks/no-aws-secrets');
+
+describe('No AWS Secrets', () => {
+  it('accepts orders with no aws config', async () => {
+    const deployment = {
+      serviceName: 'streamliner',
+      ordersPath: 'streamliner/orders',
+      ordersContents: [
+        'export AWS_REGION=us-east-1',
+        'export AWS_DEFAULT_REGION=eu-west-2',
+        'export ACCOUNT_ID=12345678'
+      ]
+    };
+
+    const results = await noAWSSecrets(deployment);
+    expect(results.length).to.equal(0);
+  });
+
+  it('warns for the presence of AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY', async () => {
+    const deployment = {
+      serviceName: 'streamliner',
+      ordersPath: 'streamliner/orders',
+      ordersContents: [
+        'export AWS_REGION=us-east-1',
+        'export AWS_DEFAULT_REGION=eu-west-2',
+        'export ACCOUNT_ID=12345678',
+        'export AWS_ACCESS_KEY_ID=$(secrets ACCESS_KEY)',
+        'export AWS_SECRET_ACCESS_KEY=$(secrets SECRET_KEY)'
+      ]
+    };
+
+    const results = await noAWSSecrets(deployment);
+    expect(results.length).to.equal(2);
+
+    expect(results[0]).to.deep.equal({
+      title: 'Remove AWS Config from your orders file.',
+      line: 4,
+      level: 'warning',
+      problems: ["You should rely on the container's role, which you can define with `policy.json`, rather than explicitly declaring AWS credentials."],
+      path: deployment.ordersPath
+    });
+
+    expect(results[1]).to.deep.equal({
+      title: 'Remove AWS Config from your orders file.',
+      line: 5,
+      level: 'warning',
+      problems: ["You should rely on the container's role, which you can define with `policy.json`, rather than explicitly declaring AWS credentials."],
+      path: deployment.ordersPath
+    });
+  });
+
+  it('fails when actual secret values are present', async () => {
+    const deployment = {
+      serviceName: 'streamliner',
+      ordersPath: 'streamliner/orders',
+      ordersContents: [
+        'export AWS_REGION=us-east-1',
+        'export AWS_DEFAULT_REGION=eu-west-2',
+        'export ACCOUNT_ID=12345678',
+        'export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE',
+        'export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+      ]
+    };
+
+    const results = await noAWSSecrets(deployment);
+    expect(results.length).to.equal(2);
+
+    expect(results[0]).to.deep.equal({
+      title: 'Remove AWS Config from your orders file.',
+      line: 4,
+      level: 'failure',
+      problems: [
+        "You should rely on the container's role, which you can define with `policy.json`, rather than explicitly declaring AWS credentials.",
+        "Remove this Access Key ID from your orders file."
+      ],
+      path: deployment.ordersPath
+    });
+
+    expect(results[1]).to.deep.equal({
+      title: 'Remove AWS Config from your orders file.',
+      line: 5,
+      level: 'failure',
+      problems: [
+        "You should rely on the container's role, which you can define with `policy.json`, rather than explicitly declaring AWS credentials.",
+        "Remove this Secret Access Key from your orders file."
+      ],
+      path: deployment.ordersPath
+    });
+  });
+})


### PR DESCRIPTION
Adding a check that **warns** for the presence of `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, and **fails** if there are actual secret values in the orders.