### PR TITLE
Out of scope vars

### DIFF
--- a/checks/index.js
+++ b/checks/index.js
@@ -17,6 +17,7 @@ module.exports = [
   require("./secrets-in-orders"),
   require("./no-carriage-return"),
   require("./no-aws-secrets"),
+  require("./no-out-of-scope-vars"),
 
   /**
    *  This should probably always be last, because it verifies that the

--- a/checks/jwt-access-flags.js
+++ b/checks/jwt-access-flags.js
@@ -1,5 +1,6 @@
 require('../typedefs');
 const core = require("@actions/core");
+const { getExportValue, suggest } = require('../util');
 
 /**
  * Accepts a deployment object, and does some kind of check
@@ -21,11 +22,7 @@ async function jwtAccessFlags(deployment) {
     if (accessFlags && accessFlags.includes("+")) {
       results.push({
         title: "Syntax Error in JWT_ACCESS_FLAGS",
-        problems: [
-          `Use a \`|\` instead \n\`\`\`suggestion
-${line.replace(/\+/g, "|")}
-\`\`\``,
-        ],
+        problems: [suggest("Use a `|` instead", line.replace(/\+/g, "|"))],
         line: i + 1,
         level: "failure",
       });
@@ -33,16 +30,6 @@ ${line.replace(/\+/g, "|")}
   }
 
   return results;
-}
-
-function getExportValue(text, varName) {
-  const regex = new RegExp(`^export ${varName}=(.*)`, "mi");
-  const match = regex.exec(text);
-
-  if (!match || match.length < 2 || match[1].length < 1) return null;
-
-  const value = match[1].replace(/['|"]/gm, "");
-  return value && value.length > 0 ? value : null;
 }
 
 module.exports = jwtAccessFlags;

--- a/checks/no-out-of-scope-vars.js
+++ b/checks/no-out-of-scope-vars.js
@@ -45,7 +45,7 @@ async function noOutOfScopeVars(deployment) {
       const { variable } = match.groups;
 
       if (!exportedVars.has(variable)) {
-        result.problems.push(`Undefined Variable: \`${variable}\``,)
+        result.problems.push(`**Undefined Variable:** \`${variable}\``,)
       }
       match = bashVar.exec(line);
     }

--- a/checks/no-out-of-scope-vars.js
+++ b/checks/no-out-of-scope-vars.js
@@ -1,0 +1,56 @@
+require("../typedefs");
+const core = require("@actions/core");
+
+const bashVar = /\$\{?(?<variable>\w+)\}?/;
+const exported = /^export (?<variable>\w+)=.+/;
+
+/**
+ * Accepts a deployment object, and does some kind of check
+ * @param {Deployment} deployment An object containing information about a deployment
+ *
+ * @returns {Array<Result>}
+ */
+async function noOutOfScopeVars(deployment) {
+  /**
+   * You should check the existance of any file you're trying to check
+   */
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
+  core.info(`No Out Of Scope Variables - ${deployment.ordersPath}`);
+  const results = [];
+  const exportedVars = new Set();
+  
+  deployment.ordersContents.forEach((line, i) => {
+    const lineNumber = i + 1;
+    
+    let match = exported.exec(line);
+    if (match) {
+      const { variable } = match.groups;
+      exportedVars.add(variable);
+    }
+
+    match = bashVar.exec(line);
+    if (match) {
+      const { variable } = match.groups;
+
+      if (!exportedVars.has(variable)) {
+        results.push({
+          title: "Out of Scope Variable Reference",
+          line: lineNumber,
+          level: "failure",
+          path: deployment.ordersPath,
+          problems: [
+            `Undefined Variable: \`${variable}\``,
+            "GDS requires that all referenced variables be defined within the `orders` file. `.starphleet` has been deprecated."
+          ]
+        })
+      }
+    }
+  });
+
+  return results;
+}
+
+module.exports = noOutOfScopeVars;

--- a/test/jwt-access-flags.js
+++ b/test/jwt-access-flags.js
@@ -39,7 +39,7 @@ describe("Valid bitwise operations in JWT_ACCESS_FLAGS", () => {
     expect(results.length).to.equal(1);
     expect(results[0].level).to.equal("failure");
     expect(results[0].problems[0]).to.equal(
-      `Use a \`|\` instead \n\`\`\`suggestion
+      `Use a \`|\` instead\n\`\`\`suggestion
 export JWT_ACCESS_FLAGS=$(($JWT_ROLE_GLG_USER | $JWT_ROLE_GLG_CLIENT))
 \`\`\``
     );

--- a/test/no-out-of-scope-vars.js
+++ b/test/no-out-of-scope-vars.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const noOutOfScopeVars = require('../checks/no-out-of-scope-vars');
 
-describe.only("No Out Of Scope Variables", () => {
+describe("No Out Of Scope Variables", () => {
   it("accepts orders with no undefined variable use.", async () => {
     const deployment = {
       serviceName: "streamliner",

--- a/test/no-out-of-scope-vars.js
+++ b/test/no-out-of-scope-vars.js
@@ -38,8 +38,8 @@ describe("No Out Of Scope Variables", () => {
       path: deployment.ordersPath,
       problems: [
         "GDS requires that all referenced variables be defined within the `orders` file. `.starphleet` has been deprecated.",
-        "Undefined Variable: `JWT_ROLE_GLG_USER`",
-        "Undefined Variable: `JWT_ROLE_GLG_CLIENT`",
+        "**Undefined Variable:** `JWT_ROLE_GLG_USER`",
+        "**Undefined Variable:** `JWT_ROLE_GLG_CLIENT`",
       ]
     })
   });

--- a/test/no-out-of-scope-vars.js
+++ b/test/no-out-of-scope-vars.js
@@ -1,0 +1,46 @@
+const { expect } = require('chai');
+const noOutOfScopeVars = require('../checks/no-out-of-scope-vars');
+
+describe.only("No Out Of Scope Variables", () => {
+  it("accepts orders with no undefined variable use.", async () => {
+    const deployment = {
+      serviceName: "streamliner",
+      ordersPath: "streamliner/orders",
+      ordersContents: [
+        "export SOMETHING=hello",
+        'MORE="You had me at $SOMETHING"',
+        'echo "${MORE}"'
+      ]
+    }
+
+    const results = await noOutOfScopeVars(deployment);
+    expect(results.length).to.equal(0);
+  });
+
+  it("rejects orders that reference undefined variables.", async () => {
+    const deployment = {
+      serviceName: "streamliner",
+      ordersPath: "streamliner/orders",
+      ordersContents: [
+        "export SOMETHING=hello",
+        'MORE="You had me at $SOMETHING"',
+        'echo "${MORE}"',
+        "export JWT_ACCESS_FLAGS=$(($JWT_ROLE_GLG_USER | $JWT_ROLE_GLG_CLIENT))"
+      ]
+    }
+
+    const results = await noOutOfScopeVars(deployment);
+    expect(results.length).to.equal(1);
+    expect(results[0]).to.deep.equal({
+      title: "Out of Scope Variable Reference",
+      line: 4,
+      level: "failure",
+      path: deployment.ordersPath,
+      problems: [
+        "GDS requires that all referenced variables be defined within the `orders` file. `.starphleet` has been deprecated.",
+        "Undefined Variable: `JWT_ROLE_GLG_USER`",
+        "Undefined Variable: `JWT_ROLE_GLG_CLIENT`",
+      ]
+    })
+  });
+})

--- a/util.js
+++ b/util.js
@@ -503,6 +503,16 @@ async function getAllDeployments(files, filesToCheck) {
   );
 }
 
+function getExportValue(text, varName) {
+  const regex = new RegExp(`^export ${varName}=(.*)`, "mi");
+  const match = regex.exec(text);
+
+  if (!match || match.length < 2 || match[1].length < 1) return null;
+
+  const value = match[1].replace(/['|"]/gm, "");
+  return value && value.length > 0 ? value : null;
+}
+
 module.exports = {
   getLinesForJSON,
   suggest,
@@ -518,5 +528,6 @@ module.exports = {
   getAllDeployments,
   clearPreviousRunComments,
   getContents,
-  camelCaseFileName
+  camelCaseFileName,
+  getExportValue,
 };


### PR DESCRIPTION
This adds a check for the use of variables that are not defined within the orders file. Many services are used to relying on `.starphleet`, and so reference variables that are defined in the parent scope. This is not permitted in GDS, so we should block when we find it.

See it in action here: https://github.com/glg/cc-screamer-testing.s99/pull/8