### PR TITLE
check for cluster dns use

### DIFF
--- a/checks/index.js
+++ b/checks/index.js
@@ -18,6 +18,7 @@ module.exports = [
   require("./no-carriage-return"),
   require("./no-aws-secrets"),
   require("./no-out-of-scope-vars"),
+  require("./use-cname"),
 
   /**
    *  This should probably always be last, because it verifies that the

--- a/checks/use-cname.js
+++ b/checks/use-cname.js
@@ -1,0 +1,62 @@
+require("../typedefs");
+const core = require("@actions/core");
+
+const envvar = /^(export |)(?<variable>\w+)=['"]?(?<value>.+?)['"]?$/;
+const clusterDNS = /^https:\/\/(?<clusterId>[spji]\d\d)\.glgresearch\.com/;
+
+/**
+ * Accepts a deployment object, and does some kind of check
+ * @param {Deployment} deployment An object containing information about a deployment
+ * @param {GitHubContext} context The context object provided by github
+ * @param {ActionInputs} inputs The inputs (excluding the token) from the github action
+ *
+ * @returns {Array<Result>}
+ */
+async function useCNAME(deployment, context, inputs) {
+  /**
+   * You should check the existance of any file you're trying to check
+   */
+  if (!deployment.ordersContents) {
+    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
+  core.info(`Use CNAME instead of cluster DNS - ${deployment.ordersPath}`);
+  const results = [];
+  /**
+   * A Result Object:
+   {
+    title: 'Failing Check',
+    problems: ['This code sucks'],
+    line: lineNumber,
+    level: 'failure' // must be "failure", "warning", "notice", or "success"
+    [path]: deployment.secretsJsonPath // This defaults to the deployment path, but you can override for different files.
+   }
+   */
+
+  deployment.ordersContents.forEach((line, i) => {
+    const lineNumber = i + 1;
+    const envvarMatch = envvar.exec(line);
+    if (envvarMatch) {
+      const { value } = envvarMatch.groups;
+
+      const clusterDNSMatch = clusterDNS.exec(value);
+      if (clusterDNSMatch) {
+        const { clusterId } = clusterDNSMatch.groups;
+        const result = {
+          title: "Use friendly CNAME instead",
+          line: lineNumber,
+          level: "warning",
+          path: deployment.ordersPath,
+          problems: [
+            `Rather than using the cluster dns (\`${clusterId}.glgresearch.com\`), consider using the friendly CNAME (e.g. \`streamliner.glgresearch.com\`)`,
+          ],
+        };
+        results.push(result);
+      }
+    }
+  });
+
+  return results;
+}
+
+module.exports = useCNAME;

--- a/test/use-cname.js
+++ b/test/use-cname.js
@@ -1,0 +1,26 @@
+const { expect } = require("chai");
+const useCNAME = require("../checks/use-cname");
+
+describe("Use CNAME instead of cluster dns", () => {
+  it("warns when it encounters a url that looks like a cluster dns", async () => {
+    const deployment = {
+      serviceName: "streamliner",
+      ordersPath: "streamliner/orders",
+      ordersContents: [
+        "export PUBLIC_URL=https://s99.glgresearch.com/streamliner",
+      ],
+    };
+
+    const results = await useCNAME(deployment);
+    expect(results.length).to.equal(1);
+    expect(results[0]).to.deep.equal({
+      title: "Use friendly CNAME instead",
+      line: 1,
+      level: "warning",
+      path: deployment.ordersPath,
+      problems: [
+        "Rather than using the cluster dns (`s99.glgresearch.com`), consider using the friendly CNAME (e.g. `streamliner.glgresearch.com`)",
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Adds a check for the use of cluster dns like `s99.glgresearch.com`, and warns that the user should use a friendly CNAME (like `streamliner.glgresearch.com`) instead.

Tested live here: https://github.com/glg/cc-screamer-testing.s99/pull/8