### PR TITLE
Even more tests

### DIFF
--- a/checks/no-sourcing.js
+++ b/checks/no-sourcing.js
@@ -17,8 +17,7 @@ async function noSourcing(deployment) {
   core.info(`No Sourcing Other Files - ${deployment.ordersPath}`);
   const results = [];
 
-  for (let i = 0; i < deployment.ordersContents.length; i++) {
-    const line = deployment.ordersContents[i];
+  deployment.ordersContents.forEach((line, i) => {
     if (sourceUse.test(line)) {
       results.push({
         title: "No Use of `source`",
@@ -29,7 +28,7 @@ async function noSourcing(deployment) {
         level: "failure",
       });
     }
-  }
+  });
 
   return results;
 }

--- a/checks/service-name.js
+++ b/checks/service-name.js
@@ -11,12 +11,7 @@ const validCharacters = /^[a-z][a-z0-9-]*$/;
  * @returns {Array<Result>}
  */
 async function validateServiceName(deployment) {
-  if (!deployment.ordersContents) {
-    core.info(`No Orders Present - Skipping ${deployment.serviceName}`);
-    return [];
-  }
-
-  core.info(`Valid Service Name - ${deployment.ordersPath}`);
+  core.info(`Valid Service Name - ${deployment.serviceName}`);
 
   const { serviceName } = deployment;
 

--- a/test/deployment-line.js
+++ b/test/deployment-line.js
@@ -2,6 +2,15 @@ const { expect } = require("chai");
 const deploymentLineCheck = require("../checks/deployment-line");
 
 describe("Deployment Line Check", () => {
+  it("skips if there is no orders file", async () => {
+    const deployment = {
+      serviceName: "streamliner"
+    };
+
+    const results = await deploymentLineCheck(deployment);
+    expect(results.length).to.equal(0);
+  });
+
   it("works with a valid deployment line", async () => {
     // works with autodeploy
     let deployment = {

--- a/test/healthcheck.js
+++ b/test/healthcheck.js
@@ -2,6 +2,27 @@ const { expect } = require("chai");
 const healthcheckCheck = require("../checks/healthcheck");
 
 describe("Healthcheck Check", () => {
+  it("skips if there is no orders file", async () => {
+    const deployment = {
+      serviceName: "streamliner"
+    };
+
+    const results = await healthcheckCheck(deployment);
+    expect(results.length).to.equal(0);
+  });
+
+  it("skips if the deployment is a job", async () => {
+    const deployment = {
+      serviceName: "streamliner",
+      ordersPath: "streamliner/orders",
+      ordersContents: ["jobdeploy github/glg/streamliner/main:latest"],
+    };
+
+    const results = await healthcheckCheck(deployment);
+
+    expect(results.length).to.equal(0);
+  });
+
   it("works with a valid healthcheck", async () => {
     const deployment = {
       serviceName: "streamliner",

--- a/test/https-only.js
+++ b/test/https-only.js
@@ -51,4 +51,13 @@ export MORE='https://services.glgresearch.com/streamliner'
 
     expect(results.length).to.equal(0);
   });
+
+  it("skips if there is no orders file", async () => {
+    const deployment = {
+      serviceName: "streamliner"
+    };
+
+    const results = await httpsOnly(deployment);
+    expect(results.length).to.equal(0);
+  });
 });

--- a/test/jwt-access-flags.js
+++ b/test/jwt-access-flags.js
@@ -44,4 +44,13 @@ export JWT_ACCESS_FLAGS=$(($JWT_ROLE_GLG_USER | $JWT_ROLE_GLG_CLIENT))
 \`\`\``
     );
   });
+
+  it("skips if there is no orders file", async () => {
+    const deployment = {
+      serviceName: "streamliner"
+    };
+
+    const results = await jwtAccessFlags(deployment);
+    expect(results.length).to.equal(0);
+  });
 });

--- a/test/no-aws-secrets.js
+++ b/test/no-aws-secrets.js
@@ -2,6 +2,15 @@ const { expect } = require("chai");
 const noAWSSecrets = require("../checks/no-aws-secrets");
 
 describe("No AWS Secrets", () => {
+  it("skips if there is no orders file", async () => {
+    const deployment = {
+      serviceName: "streamliner"
+    };
+
+    const results = await noAWSSecrets(deployment);
+    expect(results.length).to.equal(0);
+  });
+
   it("accepts orders with no aws config", async () => {
     const deployment = {
       serviceName: "streamliner",

--- a/test/no-debug-in-prod.js
+++ b/test/no-debug-in-prod.js
@@ -2,6 +2,15 @@ const { expect } = require('chai');
 const noDebugInProd = require('../checks/no-debug-in-prod');
 
 describe('No Debug In Prod', async () => {
+  it("skips if there is no orders file", async () => {
+    const deployment = {
+      serviceName: "streamliner"
+    };
+
+    const results = await noDebugInProd(deployment);
+    expect(results.length).to.equal(0);
+  });
+
   it('accepts orders file with no known debug flags', async () => {
     const deployment = {
       serviceName: "streamliner",

--- a/test/no-duplicate-exports.js
+++ b/test/no-duplicate-exports.js
@@ -2,6 +2,15 @@ const { expect } = require("chai");
 const noDupes = require("../checks/no-duplicate-exports");
 
 describe("No Duplicate Exports Check", () => {
+  it("skips if there is no orders file", async () => {
+    const deployment = {
+      serviceName: "streamliner"
+    };
+
+    const results = await noDupes(deployment);
+    expect(results.length).to.equal(0);
+  });
+
   it("allows orders with no duplicate exports", async () => {
     const deployment = {
       serviceName: "streamliner",
@@ -10,6 +19,7 @@ describe("No Duplicate Exports Check", () => {
         "export THREE=something",
         "export UNIQUE=123",
         'export VARS="quoted string"',
+        "dockerdeploy github/glg/streamliner/main:latest"
       ],
     };
 

--- a/test/no-out-of-scope-vars.js
+++ b/test/no-out-of-scope-vars.js
@@ -2,6 +2,15 @@ const { expect } = require('chai');
 const noOutOfScopeVars = require('../checks/no-out-of-scope-vars');
 
 describe("No Out Of Scope Variables", () => {
+  it("skips if there is no orders file", async () => {
+    const deployment = {
+      serviceName: "streamliner"
+    };
+
+    const results = await noOutOfScopeVars(deployment);
+    expect(results.length).to.equal(0);
+  });
+
   it("accepts orders with no undefined variable use.", async () => {
     const deployment = {
       serviceName: "streamliner",

--- a/test/no-sourcing.js
+++ b/test/no-sourcing.js
@@ -2,6 +2,15 @@ const { expect } = require("chai");
 const noSourcing = require("../checks/no-sourcing");
 
 describe("No Sourcing Check", () => {
+  it("skips if there is no orders file", async () => {
+    const deployment = {
+      serviceName: "streamliner"
+    };
+
+    const results = await noSourcing(deployment);
+    expect(results.length).to.equal(0);
+  });
+
   it("allows orders with no external sourcing", async () => {
     const deployment = {
       serviceName: "streamliner",

--- a/test/no-sourcing.js
+++ b/test/no-sourcing.js
@@ -26,7 +26,10 @@ describe("No Sourcing Check", () => {
     const deployment = {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
-      ordersContents: ["source /var/starphleet/headquarters/cookie-beta/orders"],
+      ordersContents: [
+        "source /var/starphleet/headquarters/cookie-beta/orders",
+        "export CAT=pants"
+      ],
     };
 
     const results = await noSourcing(deployment);

--- a/test/no-spaces-in-exports.js
+++ b/test/no-spaces-in-exports.js
@@ -2,6 +2,15 @@ const { expect } = require("chai");
 const noSpaces = require("../checks/no-spaces-in-exports");
 
 describe("No Spaces in Exports Check", () => {
+  it("skips if there is no orders file", async () => {
+    const deployment = {
+      serviceName: "streamliner"
+    };
+
+    const results = await noSpaces(deployment);
+    expect(results.length).to.equal(0);
+  });
+
   it("allows orders where all exports have proper spacing", async () => {
     const deployment = {
       serviceName: "streamliner",
@@ -10,6 +19,7 @@ describe("No Spaces in Exports Check", () => {
         "export HEALTHCHECK=/diagnostic",
         "export SECURITY_MODE=jwt",
         'export CAT="pants"',
+        "dockerdeploy github/glg/streamliner/main:latest"
       ],
     };
 

--- a/test/policy-json-valid.js
+++ b/test/policy-json-valid.js
@@ -1009,7 +1009,7 @@ describe("policy.json is valid", () => {
         {
           name: "MY_OTHER_SECRET",
           valueFrom:
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else:::",
+            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else:::abcdef",
         },
       ]
     };
@@ -1033,7 +1033,7 @@ describe("policy.json is valid", () => {
           Action: "secretsmanager:GetSecretValue",
           Resource: [
             "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret-??????",
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else-??????"
+            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else-abcdef"
           ]
         }
       ]

--- a/test/policy-json-valid.js
+++ b/test/policy-json-valid.js
@@ -1,6 +1,11 @@
 const { expect } = require("chai");
 const policyJsonIsValid = require("../checks/policy-json-valid");
-const { suggest, codeBlock, getNewFileLink, getOwnerRepoBranch } = require("../util");
+const {
+  suggest,
+  codeBlock,
+  getNewFileLink,
+  getOwnerRepoBranch,
+} = require("../util");
 
 const actionFmtError =
   '"Action" must be either a valid [Action String](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_action.html), or an array of valid action strings. SRE recommends as specific of an Action String as possible.';
@@ -1011,14 +1016,14 @@ describe("policy.json is valid", () => {
           valueFrom:
             "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else:::abcdef",
         },
-      ]
+      ],
     };
 
     const pr = require("./fixtures/pull-request.json");
     const context = {
       payload: {
-        pull_request: pr
-      }
+        pull_request: pr,
+      },
     };
 
     const results = await policyJsonIsValid(deployment, context);
@@ -1033,22 +1038,31 @@ describe("policy.json is valid", () => {
           Action: "secretsmanager:GetSecretValue",
           Resource: [
             "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret-??????",
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else-abcdef"
-          ]
-        }
-      ]
+            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else-abcdef",
+          ],
+        },
+      ],
     };
 
     const policyText = JSON.stringify(expectedPolicy, null, 2);
     const { owner, repo, branch } = getOwnerRepoBranch(context);
-    const newFileLink = getNewFileLink({ owner, repo, branch, filename: "streamliner/policy.json", value: policyText});
+    const newFileLink = getNewFileLink({
+      owner,
+      repo,
+      branch,
+      filename: "streamliner/policy.json",
+      value: policyText,
+    });
     expect(results[0]).to.deep.equal({
       title: "Create a policy.json",
       level: "failure",
       line: 0,
       problems: [
-        `Add a new file, \`streamliner/policy.json\`, that contains the following:\n${codeBlock(policyText, "json")}\n[Click To Add File](${newFileLink})`
-      ]
+        `Add a new file, \`streamliner/policy.json\`, that contains the following:\n${codeBlock(
+          policyText,
+          "json"
+        )}\n[Click To Add File](${newFileLink})`,
+      ],
     });
-  })
+  });
 });

--- a/test/policy-json-valid.js
+++ b/test/policy-json-valid.js
@@ -1,6 +1,6 @@
 const { expect } = require("chai");
 const policyJsonIsValid = require("../checks/policy-json-valid");
-const { suggest } = require("../util");
+const { suggest, codeBlock, getNewFileLink, getOwnerRepoBranch } = require("../util");
 
 const actionFmtError =
   '"Action" must be either a valid [Action String](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_action.html), or an array of valid action strings. SRE recommends as specific of an Action String as possible.';
@@ -996,4 +996,59 @@ describe("policy.json is valid", () => {
       problems: [problem],
     });
   });
+
+  it("proposes creating a new policy.json file if one is needed and not present", async () => {
+    const deployment = {
+      serviceName: "streamliner",
+      secretsJson: [
+        {
+          name: "MY_SECRET",
+          valueFrom:
+            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:example::",
+        },
+        {
+          name: "MY_OTHER_SECRET",
+          valueFrom:
+            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else:::",
+        },
+      ]
+    };
+
+    const pr = require("./fixtures/pull-request.json");
+    const context = {
+      payload: {
+        pull_request: pr
+      }
+    };
+
+    const results = await policyJsonIsValid(deployment, context);
+    expect(results.length).to.equal(1);
+
+    const expectedPolicy = {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Sid: "AllowSecretsAccess",
+          Effect: "Allow",
+          Action: "secretsmanager:GetSecretValue",
+          Resource: [
+            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret-??????",
+            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else-??????"
+          ]
+        }
+      ]
+    };
+
+    const policyText = JSON.stringify(expectedPolicy, null, 2);
+    const { owner, repo, branch } = getOwnerRepoBranch(context);
+    const newFileLink = getNewFileLink({ owner, repo, branch, filename: "streamliner/policy.json", value: policyText});
+    expect(results[0]).to.deep.equal({
+      title: "Create a policy.json",
+      level: "failure",
+      line: 0,
+      problems: [
+        `Add a new file, \`streamliner/policy.json\`, that contains the following:\n${codeBlock(policyText, "json")}\n[Click To Add File](${newFileLink})`
+      ]
+    });
+  })
 });

--- a/test/secrets-in-orders.js
+++ b/test/secrets-in-orders.js
@@ -32,6 +32,15 @@ const context = {
 
 
 describe("Secrets in orders file", () => {
+  it("skips if there is no orders file", async () => {
+    const deployment = {
+      serviceName: "streamliner"
+    };
+
+    const results = await secretsInOrders(deployment);
+    expect(results.length).to.equal(0);
+  });
+
   it("accepts an orders file with no use of secrets", async () => {
     const deployment = {
       serviceName: "streamliner",

--- a/test/use-cname.js
+++ b/test/use-cname.js
@@ -2,6 +2,15 @@ const { expect } = require("chai");
 const useCNAME = require("../checks/use-cname");
 
 describe("Use CNAME instead of cluster dns", () => {
+  it("skips if there is no orders file", async () => {
+    const deployment = {
+      serviceName: "streamliner"
+    };
+
+    const results = await useCNAME(deployment);
+    expect(results.length).to.equal(0);
+  });
+
   it("warns when it encounters a url that looks like a cluster dns", async () => {
     const deployment = {
       serviceName: "streamliner",

--- a/test/valid-bash-subsitution.js
+++ b/test/valid-bash-subsitution.js
@@ -2,6 +2,15 @@ const { expect } = require("chai");
 const validSubstitutionCheck = require("../checks/valid-bash-substitution");
 
 describe("Valid Bash Substitution Checker", async () => {
+  it("skips if there is no orders file", async () => {
+    const deployment = {
+      serviceName: "streamliner"
+    };
+
+    const results = await validSubstitutionCheck(deployment);
+    expect(results.length).to.equal(0);
+  });
+
   it("accepts valid bash substitutions", async () => {
     let deployment = {
       serviceName: "streamliner",


### PR DESCRIPTION
Improved test coverage of checks. Now full project is >91%:

```
-----------------------------|---------|----------|---------|---------|-------------------------------------------------
File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                               
-----------------------------|---------|----------|---------|---------|-------------------------------------------------
All files                    |   91.29 |    82.73 |    88.1 |   91.07 |                                                 
 gds-cc-screamer             |       0 |        0 |       0 |       0 |                                                 
  typedefs.js                |       0 |        0 |       0 |       0 |                                                 
 gds-cc-screamer/checks      |   96.11 |    86.97 |   98.88 |   96.05 |                                                 
  deployment-line.js         |     100 |      100 |     100 |     100 |                                                 
  healthcheck.js             |     100 |      100 |     100 |     100 |                                                 
  https-only.js              |     100 |      100 |     100 |     100 |                                                 
  jwt-access-flags.js        |     100 |      100 |     100 |     100 |                                                 
  no-aws-secrets.js          |     100 |      100 |     100 |     100 |                                                 
  no-carriage-return.js      |     100 |      100 |     100 |     100 |                                                 
  no-debug-in-prod.js        |     100 |      100 |     100 |     100 |                                                 
  no-duplicate-exports.js    |     100 |      100 |     100 |     100 |                                                 
  no-out-of-scope-vars.js    |     100 |      100 |     100 |     100 |                                                 
  no-sourcing.js             |     100 |      100 |     100 |     100 |                                                 
  no-spaces-in-exports.js    |     100 |      100 |     100 |     100 |                                                 
  policy-json-valid.js       |   94.74 |    79.17 |   97.87 |   94.72 | 177,235,252,306-308,355-356,649,653,666,670,678 
  secrets-in-orders.js       |     100 |     87.5 |     100 |     100 | 120-152                                         
  secrets-json-valid.js      |   79.25 |    87.18 |     100 |   79.25 | 81,96-114,116-137,148,152                       
  security-mode.js           |   88.57 |    76.19 |     100 |   87.88 | 14-15,19-20                                     
  service-name.js            |     100 |      100 |     100 |     100 |                                                 
  use-cname.js               |     100 |    66.67 |     100 |     100 | 27-31                                           
  valid-bash-substitution.js |     100 |      100 |     100 |     100 |                                                 
 gds-cc-screamer/util        |   70.12 |    57.81 |   62.16 |   68.18 |                                                 
  generic.js                 |     100 |      100 |     100 |     100 |                                                 
  github.js                  |   26.56 |        0 |   22.22 |   26.56 | 15-148,201-217,262-308                          
  index.js                   |     100 |      100 |     100 |     100 |                                                 
  text.js                    |   97.14 |     96.3 |     100 |   96.83 | 92,107                                          
-----------------------------|---------|----------|---------|---------|-------------------------------------------------
```