### PR TITLE
Smarter url swapping

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
   token:
     description: Should be secrets.GITHUB_TOKEN
     required: true
+  cluster_map:
+    description: A URL where a JSON mapping of cluster attributes can be retrieved
+    required: false
+    default: https://static.glgresearch.com/gds-cluster-map/cluster-map.json
   aws_account_id:
     description: The ID of your AWS account. Used to generate certain comments.
     required: false

--- a/checks/use-cname.js
+++ b/checks/use-cname.js
@@ -27,14 +27,13 @@ async function useCNAME(deployment, context, inputs, httpGet) {
   const splitName = repo.split(".");
   const repoCluster = splitName.pop();
 
-  let myCluster = { hosts: [] };
+  let clusterMap = { [repoCluster]: { hosts: [] }};
   try {
-    const clusterMap = await httpGet(inputs.clusterMap);
-    myCluster = clusterMap[repoCluster]
+    clusterMap = await httpGet(inputs.clusterMap);
   } catch (e) {
     // doesn't matter
   }
-   
+  const myCluster = clusterMap[repoCluster];
   
   deployment.ordersContents.forEach((line, i) => {
     const lineNumber = i + 1;

--- a/checks/use-cname.js
+++ b/checks/use-cname.js
@@ -33,6 +33,9 @@ async function useCNAME(deployment, context, inputs, httpGet) {
   if (clusterMap[repoCluster]) {
     myCluster = clusterMap[repoCluster];
   }
+  if (!myCluster.hosts) {
+    myCluster.hosts = [];
+  }
   
   deployment.ordersContents.forEach((line, i) => {
     const lineNumber = i + 1;

--- a/checks/use-cname.js
+++ b/checks/use-cname.js
@@ -27,13 +27,12 @@ async function useCNAME(deployment, context, inputs, httpGet) {
   const splitName = repo.split(".");
   const repoCluster = splitName.pop();
 
-  let clusterMap = { [repoCluster]: { hosts: [] }};
-  try {
-    clusterMap = await httpGet(inputs.clusterMap);
-  } catch (e) {
-    // doesn't matter
+  const clusterMap = await httpGet(inputs.clusterMap);
+  
+  let myCluster = { hosts: [] };
+  if (clusterMap[repoCluster]) {
+    myCluster = clusterMap[repoCluster];
   }
-  const myCluster = clusterMap[repoCluster];
   
   deployment.ordersContents.forEach((line, i) => {
     const lineNumber = i + 1;

--- a/checks/use-cname.js
+++ b/checks/use-cname.js
@@ -1,6 +1,6 @@
 require("../typedefs");
 const core = require("@actions/core");
-const { suggest } = require('../util');
+const { suggest } = require("../util");
 
 const envvar = /^(export |)(?<variable>\w+)=['"]?(?<value>.+?)['"]?$/;
 const clusterDNS = /^https:\/\/(?<clusterId>[spji]\d\d)\.glgresearch\.com/;
@@ -28,7 +28,7 @@ async function useCNAME(deployment, context, inputs, httpGet) {
   const repoCluster = splitName.pop();
 
   const clusterMap = await httpGet(inputs.clusterMap);
-  
+
   let myCluster = { hosts: [] };
   if (clusterMap[repoCluster]) {
     myCluster = clusterMap[repoCluster];
@@ -36,7 +36,7 @@ async function useCNAME(deployment, context, inputs, httpGet) {
   if (!myCluster.hosts) {
     myCluster.hosts = [];
   }
-  
+
   deployment.ordersContents.forEach((line, i) => {
     const lineNumber = i + 1;
     const envvarMatch = envvar.exec(line);
@@ -54,13 +54,18 @@ async function useCNAME(deployment, context, inputs, httpGet) {
           problems: [],
         };
 
-        let msg = `Rather than using the cluster dns (\`${clusterId}.glgresearch.com\`), consider using a friendly CNAME`
+        const msg = `Rather than using the cluster dns (\`${clusterId}.glgresearch.com\`), consider using a friendly CNAME`;
 
         if (myCluster.hosts.length === 0) {
           result.problems.push(`${msg} (e.g. \`streamliner.glgresearch.com\`)`);
         } else {
-          result.problems.push(`${msg} like one of the following:\n${myCluster.hosts.map((host) => suggest("", line.replace(`${clusterId}.glgresearch.com`, host))
-          ).join('\n')}`);
+          result.problems.push(
+            `${msg} like one of the following:\n${myCluster.hosts
+              .map((host) =>
+                suggest("", line.replace(`${clusterId}.glgresearch.com`, host))
+              )
+              .join("\n")}`
+          );
         }
         results.push(result);
       }

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const {
   getAllDeployments,
   suggestBugReport,
   leaveComment,
+  httpGet
 } = require("./util");
 
 /**
@@ -18,9 +19,10 @@ async function run() {
   const secretsPrefix = core.getInput("aws_secrets_prefix");
   const awsRegion = core.getInput("aws_region");
   const awsPartition = core.getInput("aws_partition");
+  const clusterMap = core.getInput("cluster_map");
 
   /** @type {ActionInputs} */
-  const inputs = { awsAccount, secretsPrefix, awsRegion, awsPartition };
+  const inputs = { awsAccount, secretsPrefix, awsRegion, awsPartition, clusterMap };
 
   const octokit = github.getOctokit(token);
 
@@ -58,7 +60,7 @@ async function run() {
       for (const check of checks) {
         let results = [];
         try {
-          results = await check(deployment, github.context, inputs);
+          results = await check(deployment, github.context, inputs, httpGet);
         } catch (e) {
           await suggestBugReport(octokit, e, "Error running check", {
             owner,

--- a/test/fixtures/cluster-map.json
+++ b/test/fixtures/cluster-map.json
@@ -1,0 +1,15 @@
+{
+  "s99": {
+    "clusterMap": "v3-s99",
+    "clusterVersion": "v3",
+    "clusterConfig": "s99",
+    "fullPath": "glgapp/route53/s99.glgresearch.com.tf",
+    "nameOfFile": "s99.glgresearch.com.tf",
+    "hosts": [
+      "cli.glgresearch.com",
+      "insights.glgresearch.com",
+      "jupyterhub.glgresearch.com",
+      "streamliner.glgresearch.com"
+    ]
+  }
+}

--- a/test/use-cname.js
+++ b/test/use-cname.js
@@ -1,13 +1,36 @@
 const { expect } = require("chai");
+const fs = require('fs').promises;
 const useCNAME = require("../checks/use-cname");
+const { suggest } = require("../util");
 
-describe("Use CNAME instead of cluster dns", () => {
+const context = {
+  payload: {
+    pull_request: {
+      base: {
+        repo: {
+          name: "gds.clusterconfig.s99",
+        },
+      },
+    },
+  },
+};
+
+const inputs = {
+  clusterMap: "test/fixtures/cluster-map.json"
+};
+
+async function localGet(path) {
+  const content = await fs.readFile(path, 'utf8');
+  return JSON.parse(content);
+}
+
+describe.only("Use CNAME instead of cluster dns", () => {
   it("skips if there is no orders file", async () => {
     const deployment = {
       serviceName: "streamliner"
     };
 
-    const results = await useCNAME(deployment);
+    const results = await useCNAME(deployment, {}, inputs, localGet);
     expect(results.length).to.equal(0);
   });
 
@@ -20,16 +43,23 @@ describe("Use CNAME instead of cluster dns", () => {
       ],
     };
 
-    const results = await useCNAME(deployment);
+    const results = await useCNAME(deployment, context, inputs, localGet);
     expect(results.length).to.equal(1);
+
+    const clusterMap = await localGet(inputs.clusterMap);
+
+    let problem = "Rather than using the cluster dns (`s99.glgresearch.com`), consider using a friendly CNAME like one of the following:\n" + clusterMap.s99.hosts.map((host) => suggest("", deployment.ordersContents[0].replace("s99.glgresearch.com", host))).join('\n');
+
     expect(results[0]).to.deep.equal({
       title: "Use friendly CNAME instead",
       line: 1,
       level: "warning",
       path: deployment.ordersPath,
       problems: [
-        "Rather than using the cluster dns (`s99.glgresearch.com`), consider using the friendly CNAME (e.g. `streamliner.glgresearch.com`)",
+        problem
       ],
     });
+
+    //"Rather than using the cluster dns (`s99.glgresearch.com`), consider using a friendly CNAME (e.g. `streamliner.glgresearch.com`)"
   });
 });

--- a/test/use-cname.js
+++ b/test/use-cname.js
@@ -3,28 +3,16 @@ const fs = require('fs').promises;
 const useCNAME = require("../checks/use-cname");
 const { suggest } = require("../util");
 
-const context = {
-  payload: {
-    pull_request: {
-      base: {
-        repo: {
-          name: "gds.clusterconfig.s99",
-        },
-      },
-    },
-  },
-};
-
-const inputs = {
-  clusterMap: "test/fixtures/cluster-map.json"
-};
-
 async function localGet(path) {
   const content = await fs.readFile(path, 'utf8');
   return JSON.parse(content);
 }
 
-describe.only("Use CNAME instead of cluster dns", () => {
+const inputs = {
+  clusterMap: "test/fixtures/cluster-map.json"
+};
+
+describe("Use CNAME instead of cluster dns", () => {
   it("skips if there is no orders file", async () => {
     const deployment = {
       serviceName: "streamliner"
@@ -34,7 +22,7 @@ describe.only("Use CNAME instead of cluster dns", () => {
     expect(results.length).to.equal(0);
   });
 
-  it("warns when it encounters a url that looks like a cluster dns", async () => {
+  it("warns and suggests valid alternatives when it encounters a url that looks like a cluster dns", async () => {
     const deployment = {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
@@ -43,12 +31,24 @@ describe.only("Use CNAME instead of cluster dns", () => {
       ],
     };
 
+    const context = {
+      payload: {
+        pull_request: {
+          base: {
+            repo: {
+              name: "gds.clusterconfig.s99",
+            },
+          },
+        },
+      },
+    };
+    
     const results = await useCNAME(deployment, context, inputs, localGet);
     expect(results.length).to.equal(1);
 
     const clusterMap = await localGet(inputs.clusterMap);
 
-    let problem = "Rather than using the cluster dns (`s99.glgresearch.com`), consider using a friendly CNAME like one of the following:\n" + clusterMap.s99.hosts.map((host) => suggest("", deployment.ordersContents[0].replace("s99.glgresearch.com", host))).join('\n');
+    const problem = "Rather than using the cluster dns (`s99.glgresearch.com`), consider using a friendly CNAME like one of the following:\n" + clusterMap.s99.hosts.map((host) => suggest("", deployment.ordersContents[0].replace("s99.glgresearch.com", host))).join('\n');
 
     expect(results[0]).to.deep.equal({
       title: "Use friendly CNAME instead",
@@ -60,6 +60,43 @@ describe.only("Use CNAME instead of cluster dns", () => {
       ],
     });
 
-    //"Rather than using the cluster dns (`s99.glgresearch.com`), consider using a friendly CNAME (e.g. `streamliner.glgresearch.com`)"
+    //
   });
+
+  it("warns and makes a generic suggestion if no friendly cname can be found", async () => {
+    const deployment = {
+      serviceName: "streamliner",
+      ordersPath: "streamliner/orders",
+      ordersContents: [
+        "export PUBLIC_URL=https://s99.glgresearch.com/streamliner",
+      ],
+    };
+
+    const context = {
+      payload: {
+        pull_request: {
+          base: {
+            repo: {
+              name: "gds.clusterconfig.s80",
+            },
+          },
+        },
+      },
+    };
+
+    const results = await useCNAME(deployment, context, inputs, localGet);
+    expect(results.length).to.equal(1);
+
+    const problem = "Rather than using the cluster dns (`s99.glgresearch.com`), consider using a friendly CNAME (e.g. `streamliner.glgresearch.com`)";
+
+    expect(results[0]).to.deep.equal({
+      title: "Use friendly CNAME instead",
+      line: 1,
+      level: "warning",
+      path: deployment.ordersPath,
+      problems: [
+        problem
+      ],
+    });
+  })
 });

--- a/test/use-cname.js
+++ b/test/use-cname.js
@@ -1,21 +1,21 @@
 const { expect } = require("chai");
-const fs = require('fs').promises;
+const fs = require("fs").promises;
 const useCNAME = require("../checks/use-cname");
 const { suggest } = require("../util");
 
 async function localGet(path) {
-  const content = await fs.readFile(path, 'utf8');
+  const content = await fs.readFile(path, "utf8");
   return JSON.parse(content);
 }
 
 const inputs = {
-  clusterMap: "test/fixtures/cluster-map.json"
+  clusterMap: "test/fixtures/cluster-map.json",
 };
 
 describe("Use CNAME instead of cluster dns", () => {
   it("skips if there is no orders file", async () => {
     const deployment = {
-      serviceName: "streamliner"
+      serviceName: "streamliner",
     };
 
     const results = await useCNAME(deployment, {}, inputs, localGet);
@@ -42,22 +42,29 @@ describe("Use CNAME instead of cluster dns", () => {
         },
       },
     };
-    
+
     const results = await useCNAME(deployment, context, inputs, localGet);
     expect(results.length).to.equal(1);
 
     const clusterMap = await localGet(inputs.clusterMap);
 
-    const problem = "Rather than using the cluster dns (`s99.glgresearch.com`), consider using a friendly CNAME like one of the following:\n" + clusterMap.s99.hosts.map((host) => suggest("", deployment.ordersContents[0].replace("s99.glgresearch.com", host))).join('\n');
+    const problem =
+      "Rather than using the cluster dns (`s99.glgresearch.com`), consider using a friendly CNAME like one of the following:\n" +
+      clusterMap.s99.hosts
+        .map((host) =>
+          suggest(
+            "",
+            deployment.ordersContents[0].replace("s99.glgresearch.com", host)
+          )
+        )
+        .join("\n");
 
     expect(results[0]).to.deep.equal({
       title: "Use friendly CNAME instead",
       line: 1,
       level: "warning",
       path: deployment.ordersPath,
-      problems: [
-        problem
-      ],
+      problems: [problem],
     });
 
     //
@@ -87,16 +94,15 @@ describe("Use CNAME instead of cluster dns", () => {
     const results = await useCNAME(deployment, context, inputs, localGet);
     expect(results.length).to.equal(1);
 
-    const problem = "Rather than using the cluster dns (`s99.glgresearch.com`), consider using a friendly CNAME (e.g. `streamliner.glgresearch.com`)";
+    const problem =
+      "Rather than using the cluster dns (`s99.glgresearch.com`), consider using a friendly CNAME (e.g. `streamliner.glgresearch.com`)";
 
     expect(results[0]).to.deep.equal({
       title: "Use friendly CNAME instead",
       line: 1,
       level: "warning",
       path: deployment.ordersPath,
-      problems: [
-        problem
-      ],
+      problems: [problem],
     });
-  })
+  });
 });

--- a/test/use-cname.js
+++ b/test/use-cname.js
@@ -67,8 +67,6 @@ describe("Use CNAME instead of cluster dns", () => {
       path: deployment.ordersPath,
       problems: [problem],
     });
-
-    //
   });
 
   it("warns and makes a generic suggestion if no friendly cname can be found", async () => {

--- a/test/use-cname.js
+++ b/test/use-cname.js
@@ -3,6 +3,7 @@ const fs = require("fs").promises;
 const useCNAME = require("../checks/use-cname");
 const { suggest } = require("../util");
 
+// This makes unit testing much simpler
 async function localGet(path) {
   const content = await fs.readFile(path, "utf8");
   return JSON.parse(content);

--- a/typedefs.js
+++ b/typedefs.js
@@ -280,7 +280,8 @@
  * awsAccount: string,
  * awsRegion: string,
  * awsPartition: string,
- * secretsPrefix: string
+ * secretsPrefix: string,
+ * clusterMap: URI
  * }} ActionInputs
  */
 

--- a/util/generic.js
+++ b/util/generic.js
@@ -65,7 +65,7 @@ function httpGet(url) {
           data += chunk;
         });
 
-        // The whole response has been received. Print out the result.
+        // The whole response has been received. Parse it and resolve the promise
         resp.on("end", () => {
           resolve(JSON.parse(data));
         });

--- a/util/generic.js
+++ b/util/generic.js
@@ -2,6 +2,7 @@ require("../typedefs");
 const path = require("path");
 const { camelCaseFileName } = require("./text");
 const fs = require("fs").promises;
+const https = require("https");
 
 const jobdeploy = /^jobdeploy (?<source>\w+)\/(?<org>[\w-]+)\/(?<repo>.+?)\/(?<branch>.+?):(?<tag>\w+)/;
 
@@ -52,8 +53,31 @@ function getExportValue(text, varName) {
   return value && value.length > 0 ? value : null;
 }
 
+function httpGet(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (resp) => {
+        let data = "";
+
+        // A chunk of data has been received.
+        resp.on("data", (chunk) => {
+          data += chunk;
+        });
+
+        // The whole response has been received. Print out the result.
+        resp.on("end", () => {
+          resolve(JSON.parse(data));
+        });
+      })
+      .on("error", (err) => {
+        reject(err);
+      });
+  });
+}
+
 module.exports = {
   isAJob,
   getContents,
   getExportValue,
+  httpGet,
 };

--- a/util/generic.js
+++ b/util/generic.js
@@ -53,6 +53,7 @@ function getExportValue(text, varName) {
   return value && value.length > 0 ? value : null;
 }
 
+// No need to pull in axios just  for this
 function httpGet(url) {
   return new Promise((resolve, reject) => {
     https

--- a/util/index.js
+++ b/util/index.js
@@ -24,7 +24,8 @@ const {
 const {
   isAJob,
   getContents,
-  getExportValue
+  getExportValue,
+  httpGet
 } = require("./generic");
 
 module.exports = {
@@ -48,4 +49,5 @@ module.exports = {
   codeBlock,
   prLink,
   lineLink,
+  httpGet
 };


### PR DESCRIPTION
This upgrades a previous check (Use CNAME). It now fetches the cluster map to provide accurate, cluster-specific url recommendations.