### PR TITLE
Stop flagging non-aws things as aws secrets

### DIFF
--- a/checks/no-aws-secrets.js
+++ b/checks/no-aws-secrets.js
@@ -7,8 +7,8 @@ const core = require("@actions/core");
  *
  * https://aws.amazon.com/blogs/security/a-safer-way-to-distribute-aws-credentials-to-ec2/
  */
-const AKID = /(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])/;
-const SAK = /(?<![A-Za-z0-9/+])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])/;
+const AKID = /^export [A-Z_]*AWS[A-Z_]*=['"]*(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])['"]*/;
+const SAK = /^export [A-Z_]*AWS[A-Z_]*=['"]*(?<![A-Za-z0-9/+])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])['"]*/;
 const AKID_ENVVAR = /^export AWS_ACCESS_KEY_ID=/;
 const SAK_ENVVAR = /^export AWS_SECRET_ACCESS_KEY=/;
 

--- a/test/no-aws-secrets.js
+++ b/test/no-aws-secrets.js
@@ -101,4 +101,37 @@ describe("No AWS Secrets", () => {
       path: deployment.ordersPath,
     });
   });
+
+  it("does not flag a git sha in a deploy line", async () => {
+    const deployment = {
+      serviceName: "marketingtestcanary",
+      ordersPath: "marketingtestcanary/orders",
+      ordersContents: [
+        "# This job is for testing CI/CD things only",
+        "",
+        "# Env vars",
+        "export LOG_LEVEL=info",
+        "",
+        "export ECS_SCHEDULED_TASK_CRON='0 22 * * *'",
+        "jobdeploy github/glg/marketing-test/main:aca02d0a803c7115887a8aa59ce2b09f8b739108"
+      ]
+    }
+
+    const results = await noAWSSecrets(deployment);
+    expect(results.length).to.equal(0);
+  });
+
+  it("does not flag New Relic keys as AWS keys", async () => {
+    const deployment = {
+      serviceName: "marketingtestcanary",
+      ordersPath: "marketingtestcanary/orders",
+      ordersContents: [
+        // this is not real
+        "export NEW_RELIC_LICENSE_KEY=afd8d93b8483a9963dc70b24bf1cf79e53ceb569" 
+      ]
+    }
+
+    const results = await noAWSSecrets(deployment);
+    expect(results.length).to.equal(0);
+  });
 });


### PR DESCRIPTION
resolves #18
resolves #19 

This makes our AWS secrets check more specific. It will no longer flag things that aren't exported, and don't include `AWS` in the variable name