### PR TITLE
add test to prove quotes don't matter

### DIFF
--- a/test/fqdn-required.js
+++ b/test/fqdn-required.js
@@ -13,11 +13,35 @@ const inputs = {
 };
 
 describe("FQDN is Required", () => {
-  it("accepts orders with a fqdn that is associated with the cluster", async () => {
+  it("accepts orders with a fqdn that is associated with the cluster #1", async () => {
     const deployment = {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
       ordersContents: ["export GDS_FQDN='streamliner.glgresearch.com'"],
+    };
+
+    const context = {
+      payload: {
+        pull_request: {
+          base: {
+            repo: {
+              name: "gds.clusterconfig.s99",
+            },
+          },
+        },
+      },
+    };
+
+    const results = await fqdnRequired(deployment, context, inputs, localGet);
+
+    expect(results.length).to.equal(0);
+  });
+
+  it("accepts orders with a fqdn that is associated with the cluster #2", async () => {
+    const deployment = {
+      serviceName: "streamliner",
+      ordersPath: "streamliner/orders",
+      ordersContents: ['export GDS_FQDN="streamliner.glgresearch.com"'],
     };
 
     const context = {


### PR DESCRIPTION
Added test while investigating #45 

As I suspected, the quotes are a non-issue, and the problem was caused by a delay in updating the cluster map