### PR TITLE
Secrets bug fixes

### DIFF
--- a/test/fixtures/cc1/test-service/policy.json
+++ b/test/fixtures/cc1/test-service/policy.json
@@ -6,7 +6,7 @@
       "Effect": "Allow",
       "Action": "secretsmanager:GetSecretValue",
       "Resource": [
-        "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET"
+        "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET"
       ]
     }
   ]

--- a/test/fixtures/cc1/test-service/secrets.json
+++ b/test/fixtures/cc1/test-service/secrets.json
@@ -1,10 +1,10 @@
 [
   {
     "name": "MY_SECRET_KEY",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:someKey::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:someKey::"
   },
   {
     "name": "MY_SECRET",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:::"
   }
 ]

--- a/test/fixtures/cc2/test-service/policy.json
+++ b/test/fixtures/cc2/test-service/policy.json
@@ -6,7 +6,7 @@
       "Effect": "Allow",
       "Action": "secretsmanager:GetSecretValue",
       "Resource": [
-        "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET"
+        "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET"
       ]
     }
   ]

--- a/test/fixtures/cc2/test-service/secrets.json
+++ b/test/fixtures/cc2/test-service/secrets.json
@@ -1,10 +1,10 @@
 [
   {
     "name": "MY_SECRET_KEY",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:someKey::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:someKey::"
   },
   {
     "name": "MY_SECRET",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:::"
   }
 ]

--- a/test/fixtures/cc2/test-service2/policy.json
+++ b/test/fixtures/cc2/test-service2/policy.json
@@ -6,7 +6,7 @@
       "Effect": "Allow",
       "Action": "secretsmanager:GetSecretValue",
       "Resource": [
-        "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET"
+        "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET"
       ]
     }
   ]

--- a/test/fixtures/cc2/test-service2/secrets.json
+++ b/test/fixtures/cc2/test-service2/secrets.json
@@ -1,10 +1,10 @@
 [
   {
     "name": "MY_SECRET_KEY",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:someKey::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:someKey::"
   },
   {
     "name": "MY_SECRET",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:::"
   }
 ]

--- a/test/fixtures/cc5/test-service/policy.json
+++ b/test/fixtures/cc5/test-service/policy.json
@@ -6,7 +6,7 @@
       "Effect": "Allow",
       "Action": "secretsmanager:GetSecretValue",
       "Resource": [
-        "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET"
+        "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET"
       ]
     }
   ]

--- a/test/fixtures/cc5/test-service/secrets.json
+++ b/test/fixtures/cc5/test-service/secrets.json
@@ -1,10 +1,10 @@
 [
   {
     "name": "MY_SECRET_KEY",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:someKey::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:someKey::"
   },
   {
     "name": "MY_SECRET",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:::"
   }
 ]

--- a/test/fixtures/cc5/test-service2/policy.json
+++ b/test/fixtures/cc5/test-service2/policy.json
@@ -6,7 +6,7 @@
       "Effect": "Allow",
       "Action": "secretsmanager:GetSecretValue",
       "Resource": [
-        "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET"
+        "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET"
       ]
     }
   ]

--- a/test/fixtures/cc5/test-service2/secrets.json
+++ b/test/fixtures/cc5/test-service2/secrets.json
@@ -1,10 +1,10 @@
 [
   {
     "name": "MY_SECRET_KEY",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:someKey::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:someKey::"
   },
   {
     "name": "MY_SECRET",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:::"
   }
 ]

--- a/test/fixtures/cc5/test-service3/policy.json
+++ b/test/fixtures/cc5/test-service3/policy.json
@@ -6,7 +6,7 @@
       "Effect": "Allow",
       "Action": "secretsmanager:GetSecretValue",
       "Resource": [
-        "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET"
+        "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET"
       ]
     }
   ]

--- a/test/fixtures/cc5/test-service3/secrets.json
+++ b/test/fixtures/cc5/test-service3/secrets.json
@@ -1,10 +1,10 @@
 [
   {
     "name": "MY_SECRET_KEY",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:someKey::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:someKey::"
   },
   {
     "name": "MY_SECRET",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:::"
   }
 ]

--- a/test/fixtures/cc5/test-service4/policy.json
+++ b/test/fixtures/cc5/test-service4/policy.json
@@ -6,7 +6,7 @@
       "Effect": "Allow",
       "Action": "secretsmanager:GetSecretValue",
       "Resource": [
-        "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET"
+        "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET"
       ]
     }
   ]

--- a/test/fixtures/cc5/test-service4/secrets.json
+++ b/test/fixtures/cc5/test-service4/secrets.json
@@ -1,10 +1,10 @@
 [
   {
     "name": "MY_SECRET_KEY",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:someKey::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:someKey::"
   },
   {
     "name": "MY_SECRET",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:::"
   }
 ]

--- a/test/fixtures/cc5/test-service5/policy.json
+++ b/test/fixtures/cc5/test-service5/policy.json
@@ -6,7 +6,7 @@
       "Effect": "Allow",
       "Action": "secretsmanager:GetSecretValue",
       "Resource": [
-        "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET"
+        "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET"
       ]
     }
   ]

--- a/test/fixtures/cc5/test-service5/secrets.json
+++ b/test/fixtures/cc5/test-service5/secrets.json
@@ -1,10 +1,10 @@
 [
   {
     "name": "MY_SECRET_KEY",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:someKey::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:someKey::"
   },
   {
     "name": "MY_SECRET",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:::"
   }
 ]

--- a/test/fixtures/issues51-53/policy.json
+++ b/test/fixtures/issues51-53/policy.json
@@ -1,0 +1,50 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "BaseLineRequirements",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:GetAuthorizationToken",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "WatchdogECSPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "ecs:ListClusters",
+        "ecs:ListContainerInstances",
+        "ecs:DescribeContainerInstances",
+        "ecs:UpdateContainerInstancesState"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PublishToWatchdogSNSTopic",
+      "Effect": "Allow",
+      "Action": "sns:Publish",
+      "Resource": "arn:aws:sns:us-east-1:111111111111:ecs-instance-watchdog"
+    },
+    {
+      "Sid": "SSMToInstance",
+      "Effect": "Allow",
+      "Action": "ssm:StartSession",
+      "Resource": [
+        "arn:aws:ec2:*:*:instance/*",
+        "arn:aws:ssm:*:*:document/AWS-StartSSHSession"
+      ]
+    },
+    {
+      "Sid": "RetrieveSSHKey",
+      "Effect": "Allow",
+      "Action": "secretsmanager:GetSecretValue",
+      "Resource": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/devopsonly/GDS_INSTANCES_PRIVATE_KEY-JAPhnA"
+    }
+  ]
+}

--- a/test/fixtures/issues51-53/secrets.json
+++ b/test/fixtures/issues51-53/secrets.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "INSTANCE_PRIVATE_KEY",
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/devopsonly/GDS_INSTANCES_PRIVATE_KEY-JAPhnA"
+  }
+]

--- a/test/no-carriage-return.js
+++ b/test/no-carriage-return.js
@@ -42,11 +42,11 @@ describe("No Carriage Return", () => {
     const secretsJson = `[\r
       {\r
         "name": "JSON_SECRET",\r
-        "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:example::"\r
+        "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:example::"\r
       },\r
       {\r
         "name": "OTHER_VALUE",\r
-        "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:newkey::"\r
+        "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:newkey::"\r
       }\r
     ]`;
 
@@ -89,7 +89,7 @@ describe("No Carriage Return", () => {
               "secretsmanager:GetSecretValue",
             ],
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
         ],
       },

--- a/test/policy-json-valid.js
+++ b/test/policy-json-valid.js
@@ -41,7 +41,7 @@ describe("policy.json is valid", () => {
               "secretsmanager:GetSecretValue",
             ],
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
         ],
       },
@@ -92,7 +92,7 @@ describe("policy.json is valid", () => {
               Effect: "Allow",
               Action: "resource:action",
               Resource:
-                "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+                "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
             },
           ],
         },
@@ -136,7 +136,7 @@ describe("policy.json is valid", () => {
               "secretsmanager:GetSecretValue",
             ],
             resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
         ],
       },
@@ -194,7 +194,7 @@ describe("policy.json is valid", () => {
       problems: [
         suggest(
           "Capitalize this key",
-          '      "Resource": "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret"'
+          '      "Resource": "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret"'
         ),
       ],
       line: 15,
@@ -218,7 +218,7 @@ describe("policy.json is valid", () => {
               "secretsmanager:GetSecretValue",
             ],
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
         ],
       },
@@ -261,7 +261,7 @@ describe("policy.json is valid", () => {
               "secretsmanager:GetSecretValue",
             ],
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
         ],
       },
@@ -331,12 +331,12 @@ describe("policy.json is valid", () => {
               "secretsmanager:GetSecretValue",
             ],
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
           {
             Action: "resource:action",
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
         ],
       },
@@ -373,7 +373,7 @@ describe("policy.json is valid", () => {
             Effect: "Allow",
             Action: "resource:action",
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
           {
             Effect: "allow", // This needs to be capitalized
@@ -387,7 +387,7 @@ describe("policy.json is valid", () => {
               "secretsmanager:GetSecretValue",
             ],
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
         ],
       },
@@ -430,13 +430,13 @@ describe("policy.json is valid", () => {
               "secretsmanager:GetSecretValue",
             ],
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
           {
             Effect: "Allow",
             Action: "wrong",
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
         ],
       },
@@ -469,7 +469,7 @@ describe("policy.json is valid", () => {
             Effect: "Allow",
             Action: "resource:action",
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
           {
             Effect: "Allow",
@@ -485,7 +485,7 @@ describe("policy.json is valid", () => {
               "secretsmanager:GetSecretValue",
             ],
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
         ],
       },
@@ -523,7 +523,7 @@ describe("policy.json is valid", () => {
             Effect: "Allow",
             Action: "resource:action",
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
           {
             Effect: "Allow",
@@ -577,13 +577,13 @@ describe("policy.json is valid", () => {
               "secretsmanager:GetSecretValue",
             ],
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
           {
             Effect: "Allow",
             Action: ["resource:*", "other:action"],
             Resource: [
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
               "wrong",
             ],
           },
@@ -623,7 +623,7 @@ describe("policy.json is valid", () => {
             Effect: "Allow",
             Action: "resource:action",
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
           {
             Effect: "Allow",
@@ -632,7 +632,7 @@ describe("policy.json is valid", () => {
               "logs:*",
             ],
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
         ],
       },
@@ -672,7 +672,7 @@ describe("policy.json is valid", () => {
             Effect: "Allow",
             Action: "secretsmanager:GetSecretValue",
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret-??????",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret-??????",
           },
           {
             Effect: "Allow",
@@ -698,12 +698,12 @@ describe("policy.json is valid", () => {
         {
           name: "MY_SECRET",
           valueFrom:
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:::",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:::",
         },
         {
           name: "MY_OTHER_SECRET",
           valueFrom:
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else:::",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/something_else:::",
         },
       ],
     };
@@ -715,7 +715,7 @@ describe("policy.json is valid", () => {
       title: "Policy is missing required secrets",
       path: "streamliner/policy.json",
       problems: [
-        "Your secrets.json requests arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else-??????, but your policy does not allow access.",
+        "Your secrets.json requests arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/something_else-??????, but your policy does not allow access.",
         "Add the following statement block\n" +
           "```suggestion\n" +
           "    },\n" +
@@ -724,7 +724,7 @@ describe("policy.json is valid", () => {
           '      "Effect": "Allow",\n' +
           '      "Action": "secretsmanager:GetSecretValue",\n' +
           '      "Resource": [\n' +
-          '        "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else-??????"\n' +
+          '        "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/something_else-??????"\n' +
           "      ]\n" +
           "    }\n" +
           "```",
@@ -742,8 +742,8 @@ describe("policy.json is valid", () => {
             Effect: "Allow",
             Action: "secretsmanager:GetSecretValue",
             Resource: [
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret-??????",
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else-??????",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret-??????",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/something_else-??????",
             ], // supports wildcards
           },
           {
@@ -770,12 +770,12 @@ describe("policy.json is valid", () => {
         {
           name: "MY_SECRET",
           valueFrom:
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:example::",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:example::",
         },
         {
           name: "MY_OTHER_SECRET",
           valueFrom:
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else:::",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/something_else:::",
         },
       ],
     };
@@ -794,8 +794,8 @@ describe("policy.json is valid", () => {
             Effect: "Allow",
             Action: "secretsmanager:GetSecretValue",
             Resource: [
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/something_else",
             ],
           },
           {
@@ -822,12 +822,12 @@ describe("policy.json is valid", () => {
         {
           name: "MY_SECRET",
           valueFrom:
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:::",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:::",
         },
         {
           name: "MY_OTHER_SECRET",
           valueFrom:
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else:::",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/something_else:::",
         },
       ],
     };
@@ -842,8 +842,8 @@ describe("policy.json is valid", () => {
         suggest(
           "IAM policies should specifiy a version suffix for secrets. This can be `??????` when you always want the latest version.",
           deployment.policyJsonContents[7].replace(
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret-??????"
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret-??????"
           )
         ),
       ],
@@ -858,8 +858,8 @@ describe("policy.json is valid", () => {
         suggest(
           "IAM policies should specifiy a version suffix for secrets. This can be `??????` when you always want the latest version.",
           deployment.policyJsonContents[8].replace(
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else",
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else-??????"
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/something_else",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/something_else-??????"
           )
         ),
       ],
@@ -877,7 +877,7 @@ describe("policy.json is valid", () => {
           {
             Effect: "Allow",
             Action: "secretsmanager:GetSecretValue",
-            Resource: "arn:aws:secretsmanager:us-east-1:868468680417:secret:*", // supports wildcards
+            Resource: "arn:aws:secretsmanager:us-east-1:111111111111:secret:*", // supports wildcards
           },
           {
             Effect: "Allow",
@@ -903,12 +903,12 @@ describe("policy.json is valid", () => {
         {
           name: "MY_SECRET",
           valueFrom:
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:example::",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:example::",
         },
         {
           name: "MY_OTHER_SECRET",
           valueFrom:
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else:::",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/something_else:::",
         },
       ],
     };
@@ -952,14 +952,14 @@ describe("policy.json is valid", () => {
           {
             Effect: "Allow",
             Action: "secretsmanager:GetSecretValue",
-            Resource: "arn:aws:secretsmanager:us-east-1:868468680417:secret:*", // supports wildcards
+            Resource: "arn:aws:secretsmanager:us-east-1:111111111111:secret:*", // supports wildcards
           },
           {
             Effect: "Allow",
             Action: [
               "ecr:DeleteSomething", // will warn about this delete
             ],
-            Resource: "arn:aws:secretsmanager:us-east-1:868468680417:secret:*", // doesn't care that this is the wrong resource type
+            Resource: "arn:aws:secretsmanager:us-east-1:111111111111:secret:*", // doesn't care that this is the wrong resource type
           },
         ],
       },
@@ -977,12 +977,12 @@ describe("policy.json is valid", () => {
         {
           name: "MY_SECRET",
           valueFrom:
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:example::",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:example::",
         },
         {
           name: "MY_OTHER_SECRET",
           valueFrom:
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else:::",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/something_else:::",
         },
       ],
     };
@@ -1009,12 +1009,12 @@ describe("policy.json is valid", () => {
         {
           name: "MY_SECRET",
           valueFrom:
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:example::",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:example::",
         },
         {
           name: "MY_OTHER_SECRET",
           valueFrom:
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else:::abcdef",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/something_else:::abcdef",
         },
       ],
     };
@@ -1037,8 +1037,8 @@ describe("policy.json is valid", () => {
           Effect: "Allow",
           Action: "secretsmanager:GetSecretValue",
           Resource: [
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret-??????",
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/something_else-abcdef",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret-??????",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/something_else-abcdef",
           ],
         },
       ],

--- a/test/secrets-exist.js
+++ b/test/secrets-exist.js
@@ -159,4 +159,52 @@ describe("Secrets Exist", () => {
 
     expect(results.length).to.equal(0);
   });
+
+  it("works when the secret name includes a version tag", async () => {
+    const secretsJson = [
+      {
+        name: "SECRET",
+        valueFrom:
+          "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/devopsonly/GDS_INSTANCES_PRIVATE_KEY-JAPhnA",
+      },
+    ];
+    const deployment = {
+      serviceName: "streamliner",
+      secretsJson,
+      secretsJsonPath: "streamliner/secrets.json",
+      secretsJsonContents: JSON.stringify(secretsJson, null, 2).split("\n"),
+    };
+
+    const context = {};
+
+    const inputs = {
+      deployinatorURL: "someurl",
+      deployinatorToken: "abcdefg",
+    };
+
+    const localGet = async () => {
+      return [
+        { name: "us-east-1/testsuite/PHRED-test" },
+        { name: "us-east-1/developmentkeys/MARKLAR_DYNAMO_AWS_ACCESS_KEY" },
+        { name: "us-east-1/testsuite/23ff0652-fc09-444b-a14d-d0d989c46cf8" },
+        {
+          name: "us-east-1/testsuite/f1b83d2f-35fb-4268-81db-2e501f0c79bc",
+          description:
+            "f1b83d2f-35fb-4268-81db-2e501f0c79bc is an object like { key }",
+        },
+        {
+          name: "us-east-1/devopsonly/GDS_INSTANCES_PRIVATE_KEY",
+        },
+        {
+          name: "us-east-1/testsuite/97e33653-dad7-41b7-b140-d503445df4e4",
+          description:
+            "97e33653-dad7-41b7-b140-d503445df4e4 is an object like { key }",
+        },
+      ];
+    };
+
+    const results = await secretsExist(deployment, context, inputs, localGet);
+
+    expect(results.length).to.equal(0);
+  });
 });

--- a/test/secrets-exist.js
+++ b/test/secrets-exist.js
@@ -19,7 +19,7 @@ describe("Secrets Exist", () => {
         {
           name: "SECRET",
           valueFrom:
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:prod/deployanator/github_token:::",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:prod/deployanator/github_token:::",
         },
       ],
     };
@@ -40,7 +40,7 @@ describe("Secrets Exist", () => {
         {
           name: "SECRET",
           valueFrom:
-            "arn:aws:secretsmanager:us-east-1:868468680417:secret:prod/deployanator/github_token:::",
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:prod/deployanator/github_token:::",
         },
       ],
     };
@@ -66,7 +66,7 @@ describe("Secrets Exist", () => {
       {
         name: "SECRET",
         valueFrom:
-          "arn:aws:secretsmanager:us-east-1:868468680417:secret:prod/deployanator/github_token:::",
+          "arn:aws:secretsmanager:us-east-1:111111111111:secret:prod/deployanator/github_token:::",
       },
     ];
     const deployment = {
@@ -120,7 +120,7 @@ describe("Secrets Exist", () => {
       {
         name: "SECRET",
         valueFrom:
-          "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/testsuite/PHRED-test:::",
+          "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/testsuite/PHRED-test:::",
       },
     ];
     const deployment = {
@@ -165,7 +165,7 @@ describe("Secrets Exist", () => {
       {
         name: "SECRET",
         valueFrom:
-          "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/devopsonly/GDS_INSTANCES_PRIVATE_KEY-JAPhnA",
+          "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/devopsonly/GDS_INSTANCES_PRIVATE_KEY-JAPhnA",
       },
     ];
     const deployment = {

--- a/test/secrets-json-valid.js
+++ b/test/secrets-json-valid.js
@@ -17,11 +17,11 @@ describe("secrets.json is valid check", () => {
     const secretsJson = `[
       {
         "name": "JSON_SECRET",
-        "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:example::"
+        "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:example::"
       },
       {
         "name": "OTHER_VALUE",
-        "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:newkey::"
+        "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:newkey::"
       },
       {
         "name": "MORE_PLAIN",
@@ -71,7 +71,7 @@ describe("secrets.json is valid check", () => {
 
   it("rejects secrets.json that is not an array", async () => {
     const secretsJson = `{
-      "JSON_SECRET": "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:example::"
+      "JSON_SECRET": "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:example::"
     }`;
 
     const deployment = {
@@ -99,11 +99,11 @@ describe("secrets.json is valid check", () => {
     const secretsJson = `[
       {
         "name": "JSON_SECRET",
-        "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:example::"
+        "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:example::"
       },
       {
         "name": "OTHER_VALUE",
-        "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:newkey::"
+        "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:newkey::"
       },
       ["some array"]
     ]`;
@@ -132,11 +132,11 @@ describe("secrets.json is valid check", () => {
   it("rejects a secrets.json where any secret is missing a required key", async () => {
     const secretsJson = `[
       {
-        "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:example::"
+        "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:example::"
       },
       {
         "name": "OTHER_VALUE",
-        "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:newkey::"
+        "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:newkey::"
       }
     ]`;
 
@@ -166,11 +166,11 @@ describe("secrets.json is valid check", () => {
     const secretsJson = `[
       {
         "name": "MY_SECRET",
-        "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:example::"
+        "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:example::"
       },
       {
         "name": "OTHER_VALUE",
-        "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:newkey::",
+        "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:newkey::",
         "extraKey": "this shouldn't be here"
       }
     ]`;
@@ -203,7 +203,7 @@ describe("secrets.json is valid check", () => {
     const secretsJson = `[
       {
         "name": "JSON_SECRET",
-        "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret:example::"
+        "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret:example::"
       },
       {
         "name": "OTHER_VALUE",

--- a/test/test-service/policy.json
+++ b/test/test-service/policy.json
@@ -6,7 +6,7 @@
       "Effect": "Allow",
       "Action": "secretsmanager:GetSecretValue",
       "Resource": [
-        "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET"
+        "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET"
       ]
     }
   ]

--- a/test/test-service/secrets.json
+++ b/test/test-service/secrets.json
@@ -1,10 +1,10 @@
 [
   {
     "name": "MY_SECRET_KEY",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:someKey::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:someKey::"
   },
   {
     "name": "MY_SECRET",
-    "valueFrom": "arn:aws:secretsmanager:us-east-1:868468680417:secret:us-east-1/production/MY_SECRET:::"
+    "valueFrom": "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:::"
   }
 ]

--- a/test/util/generic.js
+++ b/test/util/generic.js
@@ -8,6 +8,7 @@ const {
   compareSecurity,
   getMasks,
   getMaskComponents,
+  getSimpleSecret,
 } = require("../../util/generic");
 const roles = require("../fixtures/roles");
 
@@ -122,5 +123,31 @@ describe("getMaskComponents", () => {
 
     components = getMaskComponents(16);
     expect(components).to.deep.equal([16]);
+  });
+});
+
+describe("getSimpleSecret", () => {
+  it("returns the secret arn without the json key or other bits #1", () => {
+    const arn =
+      "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/devopsonly/GDS_INSTANCES_PRIVATE_KEY-JAPhnA";
+    const simpleSecret =
+      "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/devopsonly/GDS_INSTANCES_PRIVATE_KEY-JAPhnA";
+    expect(getSimpleSecret(arn)).to.equal(simpleSecret);
+  });
+
+  it("returns the secret arn without the json key or other bits #2", () => {
+    const arn =
+      "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:someKey::";
+    const simpleSecret =
+      "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET-??????";
+    expect(getSimpleSecret(arn)).to.equal(simpleSecret);
+  });
+
+  it("returns the secret arn without the json key or other bits #3", () => {
+    const arn =
+      "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET:::";
+    const simpleSecret =
+      "arn:aws:secretsmanager:us-east-1:111111111111:secret:us-east-1/production/MY_SECRET-??????";
+    expect(getSimpleSecret(arn)).to.equal(simpleSecret);
   });
 });

--- a/test/util/text.js
+++ b/test/util/text.js
@@ -85,13 +85,13 @@ describe("getLinesForJSON", () => {
             Effect: "Allow",
             Action: "resource:action",
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
           {
             Effect: "Allow",
             Action: ["resource:*", "wrong"],
             Resource:
-              "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+              "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
           },
         ],
       },
@@ -103,7 +103,7 @@ describe("getLinesForJSON", () => {
       Effect: "Allow",
       Action: ["resource:*", "wrong"],
       Resource:
-        "arn:aws:secretsmanager:us-east-1:868468680417:secret:dev/json_secret",
+        "arn:aws:secretsmanager:us-east-1:111111111111:secret:dev/json_secret",
     };
 
     const lines = getLinesForJSON(policyLines, jsonObj);

--- a/util/generic.js
+++ b/util/generic.js
@@ -85,7 +85,7 @@ function httpGet(url, options = {}) {
   });
 }
 
-const secretArn = /arn:([\w\*\-]*):secretsmanager:([\w-]*):(\d*):secret:([\w\-\/]*):?(\S*?):+(\S*?):+(\w*)/;
+const secretArn = /arn:([\w\*\-]*):secretsmanager:([\w-]*):(\d*):secret:([\w\-\/]*):?([^\s:]*):?([^\s:]*):?(\w*)/;
 function getSimpleSecret(secret) {
   const match = secretArn.exec(secret);
   if (match) {
@@ -99,6 +99,11 @@ function getSimpleSecret(secret) {
       versionId,
     ] = match.slice(1);
     let arn = `arn:${partition}:secretsmanager:${region}:${account}:secret:${secretName}`;
+
+    // If it already ends in a version ID, just return as is.
+    if (/\-\w{6}$/.test(secretName)) {
+      return arn;
+    }
 
     if (versionId) {
       arn += `-${versionId}`;


### PR DESCRIPTION
Resolves #51 
Resolves #52

This fixes some bugs related to handling secret arns that use the `-??????` suffix.

It also adds test coverage for the reported scenarios.