### PR TITLE
Use new app token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,10 +45,6 @@ inputs:
     description: A fully qualified url for an instance of Deployinator
     required: false
     default: ""
-  session_url:
-    description: A URL that can trade the app token for a session_url
-    required: false
-    default: ""
 runs:
   using: "node12"
   main: "index.js"

--- a/index.js
+++ b/index.js
@@ -15,10 +15,10 @@ const {
 log.setLevel(process.env.LOG_LEVEL || "info");
 
 /**
- * Perform all checks on all deployments included in a PR
+ * Return an object with user inputs to the action
+ * @returns {ActionInputs}
  */
-async function run() {
-  const token = core.getInput("token", { required: true });
+function getInputs() {
   const awsAccount = core.getInput("aws_account_id");
   const secretsPrefix = core.getInput("aws_secrets_prefix");
   const awsRegion = core.getInput("aws_region");
@@ -27,20 +27,11 @@ async function run() {
   const numServicesWarnThreshold = core.getInput("num_services_warn");
   const numServicesFailThreshold = core.getInput("num_services_fail");
   const clusterRoot = path.resolve(core.getInput("cluster_root"));
-  const deployinatorAppToken = core.getInput("deployinator_token");
+  const deployinatorToken = core.getInput("deployinator_token");
   const deployinatorURL = core.getInput("deployinator_url");
-  const sessionURL = core.getInput("session_url");
-
-  let deployinatorToken;
-  if (deployinatorAppToken && sessionURL) {
-    const { token: session } = await httpGet(
-      `${sessionURL}/${deployinatorAppToken}`
-    );
-    deployinatorToken = session;
-  }
 
   /** @type {ActionInputs} */
-  const inputs = {
+  return {
     awsAccount,
     secretsPrefix,
     awsRegion,
@@ -52,6 +43,14 @@ async function run() {
     deployinatorURL,
     deployinatorToken,
   };
+}
+
+/**
+ * Perform all checks on all deployments included in a PR
+ */
+async function run() {
+  const token = core.getInput("token", { required: true });
+  const inputs = getInputs();
 
   const octokit = github.getOctokit(token);
 

--- a/util/github.js
+++ b/util/github.js
@@ -129,7 +129,10 @@ async function leaveComment(
       e.errors.filter(
         (err) =>
           err.resource === "PullRequestReviewComment" &&
-          ["path", "line"].includes(err.field)
+          [
+            "pull_request_review_thread.path",
+            "pull_request_review_thread.line",
+          ].includes(err.field)
       ).length > 0
     ) {
       result.problems.unshift(


### PR DESCRIPTION
Our new gds app tokens don't have the same trade-for-session workflow as the old starphleet ones.