### PR TITLE
ignore known variables with the word "secret" in them"

### DIFF
--- a/checks/potential-secrets.js
+++ b/checks/potential-secrets.js
@@ -18,6 +18,13 @@ const reservedVars = new Set([
   "CMD",
   "ECS_SCHEDULED_TASK_CRON",
 ]);
+const allowSecretVars = new Set([
+  'SECRETS_AWS_REGION',
+  'SECRETS_CREDENTIAL_SOURCE',
+  'SECRETS_LOG_LEVEL',
+  'SECRETS_NAMESPACE',
+]);
+
 
 /**
  * Checks orders file for potential secrets
@@ -133,7 +140,7 @@ async function potentialSecrets(deployment) {
       };
       if (/password/i.test(name)) {
         result.title = "Passwords Should Be In Secrets Manager";
-      } else if (/secret/i.test(name)) {
+      } else if (/secret/i.test(name) && !allowSecretVars.has(name)) {
         result.title = "Secrets Should Be In Secrets Manager";
       } else if (!reservedVars.has(name) && !_isAnException(value)) {
         const reason = _isProblem(value);

--- a/test/potential-secrets.js
+++ b/test/potential-secrets.js
@@ -54,6 +54,21 @@ describe("Potential Secrets", () => {
     });
   });
 
+  it('should ignore known variables named "secret" with secret contents', async () => {
+    const deployment = {
+      serviceName: "streamliner",
+      ordersPath: "streamliner/orders",
+      ordersContents: [
+        'export SECRETS_AWS_REGION="us-east-1"',
+        'export SECRETS_CREDENTIAL_SOURCE="ims"',
+        'export SECRETS_LOG_LEVEL="error"',
+        'export SECRETS_NAMESPACE="production"',
+      ],
+    };
+
+    expect(await potentialSecrets(deployment)).to.have.lengthOf(0);
+  });
+
   it("warns for environment variables with high entropy", async () => {
     const deployment = {
       serviceName: "streamliner",


### PR DESCRIPTION
Ignores the following variables:

* SECRETS_AWS_REGION
* SECRETS_CREDENTIAL_SOURCE
* SECRETS_LOG_LEVEL
* SECRETS_NAMESPACE