### PR TITLE
skip max services check for jobs clusters

### DIFF
--- a/checks/max-services-per-cluster.js
+++ b/checks/max-services-per-cluster.js
@@ -2,6 +2,7 @@ require("../typedefs");
 const log = require("loglevel");
 const path = require("path");
 const fs = require("fs").promises;
+const { getClusterType } = require("../util");
 
 /**
  * Accepts a deployment object, and does some kind of check
@@ -12,13 +13,15 @@ const fs = require("fs").promises;
  * @returns {Array<Result>}
  */
 async function maxServicesPerCluster(deployment, context, inputs) {
+  const clusterType = getClusterType(context);
+  if (clusterType === "jobs") {
+    log.info(`Jobs Cluster - Skipping Check: Max Services Per Cluster`);
+    return [];
+  }
   log.info(`Max Services Per Cluster - ${deployment.serviceName}`);
 
-  const {
-    numServicesWarnThreshold,
-    numServicesFailThreshold,
-    clusterRoot,
-  } = inputs;
+  const { numServicesWarnThreshold, numServicesFailThreshold, clusterRoot } =
+    inputs;
 
   const numDeployments = await getNumDeployments(clusterRoot);
 

--- a/test/max-services-per-cluster.js
+++ b/test/max-services-per-cluster.js
@@ -3,40 +3,68 @@ const maxServicesPerCluster = require("../checks/max-services-per-cluster");
 const path = require("path");
 
 describe("Max Services Per Cluster", () => {
-  it("accepts a deployment when there are few existing deployments", async () => {
-    const deployment = {
-      serviceName: "streamliner",
-    };
+  const deployment = {
+    serviceName: "streamliner",
+  };
 
+  const context = {
+    payload: {
+      pull_request: {
+        base: {
+          repo: {
+            name: "gds.clusterconfig.s99",
+          },
+        },
+      },
+    },
+  };
+
+  it("accepts a deployment when there are few existing deployments", async () => {
     const inputs = {
       numServicesFailThreshold: 4,
       numServicesWarnThreshold: 2,
       clusterRoot: path.join(process.cwd(), "test", "fixtures", "cc1"),
     };
 
-    const results = await maxServicesPerCluster(deployment, undefined, inputs);
+    const results = await maxServicesPerCluster(deployment, context, inputs);
     expect(results.length).to.equal(0);
   });
 
   it("warns when the number of deployments is approaching the limit", async () => {
-    const deployment = {
-      serviceName: "streamliner",
-    };
-
     const inputs = {
       numServicesFailThreshold: 4,
       numServicesWarnThreshold: 2,
       clusterRoot: path.join(process.cwd(), "test", "fixtures", "cc2"),
     };
 
-    const results = await maxServicesPerCluster(deployment, undefined, inputs);
+    const results = await maxServicesPerCluster(deployment, context, inputs);
     expect(results.length).to.equal(1);
     expect(results[0].level).to.equal("warning");
   });
 
   it("rejects deployments that would cause there to be too many deployments in the cluster", async () => {
-    const deployment = {
-      serviceName: "streamliner",
+    const inputs = {
+      numServicesFailThreshold: 4,
+      numServicesWarnThreshold: 2,
+      clusterRoot: path.join(process.cwd(), "test", "fixtures", "cc5"),
+    };
+
+    const results = await maxServicesPerCluster(deployment, context, inputs);
+    expect(results.length).to.equal(1);
+    expect(results[0].level).to.equal("failure");
+  });
+
+  it("skips this check for jobs clusters", async () => {
+    const context = {
+      payload: {
+        pull_request: {
+          base: {
+            repo: {
+              name: "gds.clusterconfig.j99",
+            },
+          },
+        },
+      },
     };
 
     const inputs = {
@@ -45,8 +73,7 @@ describe("Max Services Per Cluster", () => {
       clusterRoot: path.join(process.cwd(), "test", "fixtures", "cc5"),
     };
 
-    const results = await maxServicesPerCluster(deployment, undefined, inputs);
-    expect(results.length).to.equal(1);
-    expect(results[0].level).to.equal("failure");
+    const results = await maxServicesPerCluster(deployment, context, inputs);
+    expect(results.length).to.equal(0);
   });
 });


### PR DESCRIPTION
resolves #80 

The limit of 100 services per cluster is because of a limit on the number of rules on an application load balancer. Jobs clusters don't have a load balancer, and are therefore unencumbered by this restriction.