### PR TITLE
suggest refreshing the cache

### DIFF
--- a/checks/deployment-line.js
+++ b/checks/deployment-line.js
@@ -133,12 +133,13 @@ async function validateDeploymentLine(deployment, context, inputs, httpGet) {
     const { org: owner, repo, branch, tag } = deploymentParts;
 
     if (deploymentType === "autodeploy") {
+      const url = `${inputs.deployinatorURL}/enumerate/branches?owner=${owner}&repo=${repo}`;
       try {
-        const url = `${inputs.deployinatorURL}/enumerate/branches?owner=${owner}&repo=${repo}`;
         const { data: branches } = await httpGet(url, httpOpts);
         if (!branches.includes(branch)) {
           problems.push(
-            `The specified repo \`${owner}/${repo}\` does not have a branch named \`${branch}\``
+            `The specified repo \`${owner}/${repo}\` does not have a branch named \`${branch}\``,
+            `Sometimes this happens because of a stale cache. You can try [refreshing the cache](${url}&bust=true), and then re-running this check suite.`
           );
         }
       } catch ({ error, statusCode }) {
@@ -150,7 +151,8 @@ async function validateDeploymentLine(deployment, context, inputs, httpGet) {
           level = "notice";
         } else if (statusCode === 404) {
           problems.push(
-            `The specified repo \`${deploymentParts.org}/${deploymentParts.repo}\` could not be found.`
+            `The specified repo \`${deploymentParts.org}/${deploymentParts.repo}\` could not be found.`,
+            `Sometimes this happens because of a stale cache. You can try [refreshing the cache](${url}&bust=true), and then re-running this check suite.`
           );
         } else if (statusCode >= 500) {
           title = "Internal Server Error";
@@ -164,12 +166,13 @@ async function validateDeploymentLine(deployment, context, inputs, httpGet) {
       }
     } else {
       const image = `github/${owner}/${repo}/${branch}`;
+      const url = `${inputs.deployinatorURL}/enumerate/ecr/tags?image=${image}`;
       try {
-        const url = `${inputs.deployinatorURL}/enumerate/ecr/tags?image=${image}`;
         const { data: tags } = await httpGet(url, httpOpts);
         if (!tags.includes(tag)) {
           problems.push(
             `The docker image \`${image}\` does not have a tag named \`${tag}\``,
+            `Sometimes this happens because of a stale cache. You can try [refreshing the cache](${url}&bust=true), and then re-running this check suite.`,
             `[More About Deploying To GDS](https://services.glgresearch.com/know/glg-deployment-system-gds/deploying-a-service/)`
           );
         }
@@ -183,6 +186,7 @@ async function validateDeploymentLine(deployment, context, inputs, httpGet) {
         } else if (statusCode === 404) {
           problems.push(
             `The specified docker image \`${image}:${tag}\` could not be found.`,
+            `Sometimes this happens because of a stale cache. You can try [refreshing the cache](${url}&bust=true), and then re-running this check suite.`,
             `[More About Deploying To GDS](https://services.glgresearch.com/know/glg-deployment-system-gds/deploying-a-service/)`
           );
         } else if (statusCode >= 500) {

--- a/checks/secrets-exist.js
+++ b/checks/secrets-exist.js
@@ -107,7 +107,10 @@ async function secretsExist(deployment, context, inputs, httpGet) {
           level: "warning",
           line,
           path: deployment.secretsJsonPath,
-          problems: [`The following secret could not be found: \`${value}\``],
+          problems: [
+            `The following secret could not be found: \`${value}\``,
+            `Sometimes this happens because of a stale cache. You can try [refreshing the cache](${secretsURL}?bust=true), and then re-running this check suite.`,
+          ],
         });
       }
     }

--- a/test/deployment-line.js
+++ b/test/deployment-line.js
@@ -236,7 +236,7 @@ describe("Deployment Line Check", () => {
       localGet
     );
 
-    expect(results[0].problems.length).to.equal(1);
+    expect(results[0].problems.length).to.equal(2);
     expect(/not.*?found/i.test(results[0].problems[0])).to.be.true;
     expect(results[0].level).to.equal("failure");
   });
@@ -264,7 +264,7 @@ describe("Deployment Line Check", () => {
       localGet
     );
 
-    expect(results[0].problems.length).to.equal(1);
+    expect(results[0].problems.length).to.equal(2);
     expect(/branch/i.test(results[0].problems[0])).to.be.true;
     expect(results[0].level).to.equal("failure");
   });
@@ -292,7 +292,7 @@ describe("Deployment Line Check", () => {
       localGet
     );
 
-    expect(results[0].problems.length).to.equal(2);
+    expect(results[0].problems.length).to.equal(3);
     expect(/not.*?found/i.test(results[0].problems[0])).to.be.true;
     expect(results[0].level).to.equal("failure");
   });
@@ -320,7 +320,7 @@ describe("Deployment Line Check", () => {
       localGet
     );
 
-    expect(results[0].problems.length).to.equal(2);
+    expect(results[0].problems.length).to.equal(3);
     expect(/tag/i.test(results[0].problems[0])).to.be.true;
     expect(results[0].level).to.equal("failure");
   });

--- a/test/secrets-exist.js
+++ b/test/secrets-exist.js
@@ -115,6 +115,7 @@ describe("Secrets Exist", () => {
       path: "streamliner/secrets.json",
       problems: [
         "The following secret could not be found: `prod/deployanator/github_token`",
+        `Sometimes this happens because of a stale cache. You can try [refreshing the cache](${inputs.deployinatorURL}/enumerate/secrets?bust=true), and then re-running this check suite.`,
       ],
     });
   });


### PR DESCRIPTION
There are some situations where CC screamer will flag things as nonexistant, even if they exist. This is due to a stale cache in deployinator. Now, these messages will include instructions for refreshing the cache.

resolves #84 