### PR TITLE
Use deployinator to fetch cluster-map

### DIFF
--- a/checks/use-cname.js
+++ b/checks/use-cname.js
@@ -37,7 +37,7 @@ async function useCNAME(deployment, context, inputs, httpGet) {
         Authorization: `Bearer ${inputs.deployinatorToken}`,
       },
     };
-    const clusterMapURL = `${inputs.deployinatorURL}/cluster-map.json`;
+    const clusterMapURL = `${inputs.deployinatorURL}/cluster-map.json?bust=true`;
     const { data: clusterMap } = await httpGet(clusterMapURL, httpOpts);
 
     let myCluster = { hosts: [] };

--- a/checks/use-cname.js
+++ b/checks/use-cname.js
@@ -19,6 +19,10 @@ async function useCNAME(deployment, context, inputs, httpGet) {
     log.info(`No Orders Present - Skipping ${deployment.serviceName}`);
     return [];
   }
+  if (!inputs.deployinatorURL || !inputs.deployinatorToken) {
+    log.info("No Deployinator Config, Skipping");
+    return [];
+  }
   log.info(`Use CNAME instead of cluster DNS - ${deployment.ordersPath}`);
   /** @type {Array<Result>} */
   const results = [];
@@ -28,7 +32,13 @@ async function useCNAME(deployment, context, inputs, httpGet) {
   const repoCluster = splitName.pop();
 
   try {
-    const { data: clusterMap } = await httpGet(inputs.clusterMap);
+    const httpOpts = {
+      headers: {
+        Authorization: `Bearer ${inputs.deployinatorToken}`,
+      },
+    };
+    const clusterMapURL = `${inputs.deployinatorURL}/cluster-map.json`;
+    const { data: clusterMap } = await httpGet(clusterMapURL, httpOpts);
 
     let myCluster = { hosts: [] };
     if (clusterMap[repoCluster]) {

--- a/test/use-cname.js
+++ b/test/use-cname.js
@@ -2,16 +2,22 @@ const { expect } = require("chai");
 const fs = require("fs").promises;
 const useCNAME = require("../checks/use-cname");
 const { suggest } = require("../util");
-
-// This makes unit testing much simpler
-async function localGet(path) {
-  const content = await fs.readFile(path, "utf8");
-  return { data: JSON.parse(content) };
-}
+const path = require("path");
 
 const inputs = {
-  clusterMap: "test/fixtures/cluster-map.json",
+  deployinatorURL: "https://deployinator.com",
+  deployinatorToken: "abcdefg",
 };
+
+// This makes unit testing much simpler
+async function localGet(url) {
+  const file = url.split(`${inputs.deployinatorURL}/`)[1];
+  const content = await fs.readFile(
+    path.join(process.cwd(), "test", "fixtures", file),
+    "utf8"
+  );
+  return { data: JSON.parse(content) };
+}
 
 describe("Use CNAME instead of cluster dns", () => {
   it("skips if there is no orders file", async () => {
@@ -47,7 +53,9 @@ describe("Use CNAME instead of cluster dns", () => {
     const results = await useCNAME(deployment, context, inputs, localGet);
     expect(results.length).to.equal(1);
 
-    const { data: clusterMap } = await localGet(inputs.clusterMap);
+    const { data: clusterMap } = await localGet(
+      `${inputs.deployinatorURL}/cluster-map.json`
+    );
 
     const problem =
       "Rather than using the cluster dns (`s99.glgresearch.com`), consider using a friendly CNAME like one of the following:\n" +

--- a/test/use-cname.js
+++ b/test/use-cname.js
@@ -10,10 +10,9 @@ const inputs = {
 };
 
 // This makes unit testing much simpler
-async function localGet(url) {
-  const file = url.split(`${inputs.deployinatorURL}/`)[1];
+async function localGet() {
   const content = await fs.readFile(
-    path.join(process.cwd(), "test", "fixtures", file),
+    path.join(process.cwd(), "test", "fixtures", "cluster-map.json"),
     "utf8"
   );
   return { data: JSON.parse(content) };


### PR DESCRIPTION
CC Screamer will now use deployinator to get the cluster-map, so it will always have the latest domain info