### PR TITLE
add check for double-quotes values

### DIFF
--- a/checks/double-quotes.js
+++ b/checks/double-quotes.js
@@ -1,0 +1,69 @@
+require("../typedefs");
+const log = require("loglevel");
+const { suggest } = require("../util");
+
+const doubleQuoted = /^["']{2}.*["']{2}$/;
+const envvar = /^(export |)(?<variable>\w+)=(?<value>.+)$/;
+const bashSubstitution = /\${?[\w\-]+}?/;
+
+/**
+ * Accepts a deployment object, and does some kind of check
+ * @param {Deployment} deployment An object containing information about a deployment
+ * @param {GitHubContext} context The context object provided by github
+ * @param {ActionInputs} inputs The inputs (excluding the token) from the github action
+ * @param {function(string, (object | undefined)):Promise} httpGet
+ *
+ * @returns {Array<Result>}
+ */
+async function doubleQuotes(deployment, context, inputs, httpGet) {
+  /**
+   * You should check the existance of any file you're trying to check
+   */
+  if (!deployment.ordersContents) {
+    log.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
+  log.info(`Template Check - ${deployment.ordersPath}`);
+
+  /** @type {Array<Result>} */
+  const results = [];
+
+  deployment.ordersContents.forEach((line, i) => {
+    // GitHub lines are 1-indexed
+    const lineNumber = i + 1;
+
+    const match = envvar.exec(line);
+    if (match) {
+      const { value } = match.groups;
+      if (doubleQuoted.test(value)) {
+        const result = {
+          title: "Double Quoted Value",
+          level: "notice",
+          line: lineNumber,
+          path: deployment.ordersPath,
+          problems: [],
+        };
+
+        if (bashSubstitution.test(value)) {
+          const fixedValue = value
+            .replace(/^['"]{2}/, '"')
+            .replace(/['"]{2}$/, '"');
+          const fixed = line.replace(value, fixedValue);
+          result.problems.push(suggest("Just use double quotes", fixed));
+        } else {
+          const fixedValue = value
+            .replace(/^['"]{2}/, "'")
+            .replace(/['"]{2}$/, "'");
+          const fixed = line.replace(value, fixedValue);
+          result.problems.push(suggest("Just use single quotes", fixed));
+        }
+
+        results.push(result);
+      }
+    }
+  });
+
+  return results;
+}
+
+module.exports = doubleQuotes;

--- a/checks/index.js
+++ b/checks/index.js
@@ -26,6 +26,7 @@ const validateCron = require("./validate-cron");
 const ecsScheduledTaskCount = require("./ecs-scheduled-task-count");
 const jobsOnlyOnJobs = require("./jobs-only-on-jobs");
 const restrictedBuckets = require("./restricted-buckets");
+const doubleQuotes = require("./double-quotes");
 
 /**
  * Exports an array of async functions
@@ -59,6 +60,7 @@ module.exports = {
   ecsScheduledTaskCount,
   jobsOnlyOnJobs,
   restrictedBuckets,
+  doubleQuotes,
 
   // Also export as an array for use by checksuite
   all: [
@@ -88,6 +90,7 @@ module.exports = {
     secretsExist,
     ecsScheduledTaskCount,
     jobsOnlyOnJobs,
+    doubleQuotes,
 
     /**
      *  This should always be after checks for orders and secrets.json, because it verifies that the

--- a/checks/potential-secrets.js
+++ b/checks/potential-secrets.js
@@ -25,6 +25,7 @@ const allowSecretVars = new Set([
   "SECRETS_CREDENTIAL_SOURCE",
   "SECRETS_LOG_LEVEL",
   "SECRETS_NAMESPACE",
+  "BLOCKED_SECRET_NAMESPACES",
 ]);
 
 /**

--- a/test/double-quotes.js
+++ b/test/double-quotes.js
@@ -1,0 +1,54 @@
+const { expect } = require("chai");
+const doubleQuotes = require("../checks/double-quotes");
+
+describe("doubleQuotes", () => {
+  it("suggests using only `'` if the doublequoted value does not contain bash substitution", async () => {
+    const deployment = {
+      serviceName: "streamliner",
+      ordersPath: "streamliner/orders",
+      ordersContents: [
+        `export OUTLOOK_API_SERVER='"https://streamliner-internal.glgresearch.com/outlook-api-v2"'`,
+      ],
+    };
+
+    const results = await doubleQuotes(deployment);
+    expect(results.length).to.equal(1);
+    expect(results[0]).to.deep.equal({
+      title: "Double Quoted Value",
+      level: "notice",
+      line: 1,
+      path: "streamliner/orders",
+      problems: [
+        "Just use single quotes\n" +
+          "```suggestion\n" +
+          `export OUTLOOK_API_SERVER='https://streamliner-internal.glgresearch.com/outlook-api-v2'\n` +
+          "```",
+      ],
+    });
+  });
+
+  it('suggests using only `"` if the doublequoted value contains bash subsitution', async () => {
+    const deployment = {
+      serviceName: "streamliner",
+      ordersPath: "streamliner/orders",
+      ordersContents: [
+        `export OUTLOOK_API_SERVER='"https://\${STARPHLEET_URL}/outlook-api-v2"'`,
+      ],
+    };
+
+    const results = await doubleQuotes(deployment);
+    expect(results.length).to.equal(1);
+    expect(results[0]).to.deep.equal({
+      title: "Double Quoted Value",
+      level: "notice",
+      line: 1,
+      path: "streamliner/orders",
+      problems: [
+        "Just use double quotes\n" +
+          "```suggestion\n" +
+          `export OUTLOOK_API_SERVER="https://\${STARPHLEET_URL}/outlook-api-v2"\n` +
+          "```",
+      ],
+    });
+  });
+});


### PR DESCRIPTION
resolves #98

The root problem of that issue is that deployinator wrote the orders with multiple quotes. That issue has been resolved, and this pr adds a check for double-quoted values.