### PR TITLE
add exception for CSL

### DIFF
--- a/checks/potential-secrets.js
+++ b/checks/potential-secrets.js
@@ -90,6 +90,25 @@ async function potentialSecrets(deployment) {
     );
   }
 
+  /**
+   * Returns true for comma-separated lists
+   * which do not contain secrets within them.
+   */
+  const isListOfNonSecrets = {
+    test: (txt) => {
+      const list = txt.split(",");
+      if (list.length === 1) {
+        return false;
+      }
+      for (const item of list) {
+        if (!_isAnException(item) && _isProblem(item)) {
+          return false;
+        }
+      }
+      return true;
+    },
+  };
+
   function _isAnException(str) {
     str = str.trim();
     const regex = [
@@ -103,6 +122,7 @@ async function potentialSecrets(deployment) {
       isAnEpiTemplate,
       containsURL,
       isAFile,
+      isListOfNonSecrets,
     ];
 
     const validators = [

--- a/test/potential-secrets.js
+++ b/test/potential-secrets.js
@@ -120,6 +120,8 @@ describe("Potential Secrets", () => {
         "export PRIVATE_SECRET_NAMESPACES='devopsonly:DevOps|dbadmin:DevOps,DRE|/^production/EPISTREAM_CONNECTION_/:DRE,DevOps'",
         "export REDIRECT_MATCHERS='*=>https://session.glgresearch.com/auth0-cm/logout'",
         'export JOBS_STATUS_FILE="job_statuses.ini"',
+        "export GRANT_DEV_MODE_DEV='sbazli, patelkr, cmcculloch, mastover, twise, dhunt'",
+        "export GRANT_CREATE_MODE_OTHERS='ltran, agiurea, jsmall, aagrawal1, akapoor, ychopra, poorva.verma, mmalik, jvarghese, asis.chadha, smondal, arathore, rpahadia, vkrishna, asheorain'",
       ],
     };
 


### PR DESCRIPTION
resolves #131 

Adds an exception to the secrets checker for comma-separated lists, when that list does not contain secrets as items.