### PR TITLE
Validation checks for CMD and ENTRYPOINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,11 +234,12 @@ Runs the [shellcheck](https://github.com/koalaman/shellcheck) utility on the ord
 
 ### validJsonArraysInBash
 
-Makes sure CMD and ENTRYPOINT in your orders are structured correctly
+- CMD, if present, must be a valid stringified JSON Array a bash variable.
+- ENTRYPOINT, if present, must be a valid stringified JSON Array a bash variable.
 
 ### entrypointRequiresCmd
 
-Makes sure if you have ENTRYPOINT in your orders, you also have CMD
+- If ENTRYPOINT is defined, then CMD must also be defined.
 
 ## Adding Checks
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ This is a github action for validating PRs to GDS Cluster Configs. It evaluates 
     - [restrictedBuckets](#restrictedbuckets)
     - [validBetas](#validbetas)
     - [shellcheck](#shellcheck)
+    - [validJsonArraysInBash](#validJsonarraysinbash)
+    - [entrypointRequiresCmd](#entrypointrequirescmd)
   - [Adding Checks](#adding-checks)
   - [Who's the goat?](#whos-the-goat)
 
@@ -229,6 +231,14 @@ jobs:
 ### shellcheck
 
 Runs the [shellcheck](https://github.com/koalaman/shellcheck) utility on the orders file to check for valid bash
+
+### validJsonArraysInBash
+
+Makes sure CMD and ENTRYPOINT in your orders are structured correctly
+
+### entrypointRequiresCmd
+
+Makes sure if you have ENTRYPOINT in your orders, you also have CMD
 
 ## Adding Checks
 

--- a/checks/double-quotes.js
+++ b/checks/double-quotes.js
@@ -2,6 +2,8 @@ require("../typedefs");
 const log = require("loglevel");
 const { suggest } = require("../util");
 
+// another check provides better guidance for these variables
+const EXCLUDED_VARIABLE_NAMES = ["CMD", "ENTRYPOINT"];
 const doubleQuoted = /^["']{2}.*["']{2}$/;
 const envvar = /^(export |)(?<variable>\w+)=(?<value>.+)$/;
 const bashSubstitution = /\${?[\w\-]+}?/;
@@ -35,7 +37,7 @@ async function doubleQuotes(deployment, context, inputs, httpGet) {
     const match = envvar.exec(line);
     if (match) {
       const { value } = match.groups;
-      if (doubleQuoted.test(value)) {
+      if (doubleQuoted.test(value) && !EXCLUDED_VARIABLE_NAMES.includes(match.groups.variable)) {
         const result = {
           title: "Double Quoted Value",
           level: "notice",

--- a/checks/entrypoint-requires-cmd.js
+++ b/checks/entrypoint-requires-cmd.js
@@ -1,0 +1,56 @@
+require("../typedefs");
+const log = require("loglevel");
+
+/**
+ * Accepts a deployment object, and checks that if ENTRYPOINT is used, CMD is also
+ * @param {Deployment} deployment An object containing information about a deployment
+ * @param {GitHubContext} context The context object provided by github
+ * @param {ActionInputs} inputs The inputs (excluding the token) from the github action
+ * @param {function(string, (object | undefined)):Promise} httpGet
+ *
+ * @returns {Array<Result>}
+ */
+async function entrypointRequiresCmd(deployment, context, inputs, httpGet) {
+  /**
+   * You should check the existance of any file you're trying to check
+   */
+  if (!deployment.ordersContents) {
+    log.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
+  log.info(`Template Check - ${deployment.ordersPath}`);
+
+  /** @type {Array<Result>} */
+  const results = [];
+
+  let hasCmd = false;
+  let hasEntrypoint = false;
+  let entrypointLineNo = 0;
+  deployment.ordersContents.forEach((line, i) => {
+    // GitHub lines are 1-indexed
+    const lineNumber = i + 1;
+    // this test only checks CMD and ENTRYPOINT values
+    hasCmd = /export\s+CMD/.test(line) || hasCmd;
+    const thisLineHasEntrypoint = /export\s+ENTRYPOINT/.test(line)
+    hasEntrypoint = thisLineHasEntrypoint || hasEntrypoint;
+    if (thisLineHasEntrypoint) {
+      entrypointLineNo = lineNumber;
+    }
+
+  });
+
+  if (hasEntrypoint && !hasCmd) {
+    results.push({
+      title: `ENTRYPOINT requires CMD`,
+      problems: [
+        `Using ENTRYPOINT to override the docker image requires that you also override CMD.\nSee https://docs.docker.com/engine/reference/run/#entrypoint-default-command-to-execute-at-runtime`
+      ],
+      line: entrypointLineNo,
+      level: "failure",
+    });
+  }
+
+  return results;
+}
+
+module.exports = entrypointRequiresCmd;

--- a/checks/entrypoint-requires-cmd.js
+++ b/checks/entrypoint-requires-cmd.js
@@ -18,7 +18,7 @@ async function entrypointRequiresCmd(deployment, context, inputs, httpGet) {
     log.info(`No Orders Present - Skipping ${deployment.serviceName}`);
     return [];
   }
-  log.info(`Template Check - ${deployment.ordersPath}`);
+  log.info(`ENTRYPOINT Requires CMD - ${deployment.ordersPath}`);
 
   /** @type {Array<Result>} */
   const results = [];

--- a/checks/index.js
+++ b/checks/index.js
@@ -29,8 +29,8 @@ const restrictedBuckets = require("./restricted-buckets");
 const doubleQuotes = require("./double-quotes");
 const validBetas = require("./valid-betas");
 const shellcheck = require("./shellcheck");
-const validJsonArraysInBashCheck = require("valid-json-arrays-in-bash")
-const entrypointRequiresCmdCheck = require("entrypoint-requires-cmd");
+const validJsonArraysInBashCheck = require("./valid-json-arrays-in-bash")
+const entrypointRequiresCmdCheck = require("./entrypoint-requires-cmd");
 
 /**
  * Exports all checks in an appropriate order

--- a/checks/index.js
+++ b/checks/index.js
@@ -29,6 +29,8 @@ const restrictedBuckets = require("./restricted-buckets");
 const doubleQuotes = require("./double-quotes");
 const validBetas = require("./valid-betas");
 const shellcheck = require("./shellcheck");
+const validJsonArraysInBashCheck = require("valid-json-arrays-in-bash")
+const entrypointRequiresCmdCheck = require("entrypoint-requires-cmd");
 
 /**
  * Exports all checks in an appropriate order
@@ -63,6 +65,8 @@ module.exports = {
   doubleQuotes,
   validBetas,
   shellcheck,
+  validJsonArraysInBashCheck,
+  entrypointRequiresCmdCheck,
 
   /**
    *  This should always be after checks for orders and secrets.json, because it verifies that the

--- a/checks/valid-bash-substitution.js
+++ b/checks/valid-bash-substitution.js
@@ -4,6 +4,7 @@ const log = require("loglevel");
 // we expect these to match the regex, but they should not be flagged
 const EXCLUDED_VARIABLE_NAMES = [
   'CMD',
+  'ENTRYPOINT',
 ];
 const singleQuoteSubsitution = /export (?<variable>\w+)='.*\$({|)\w+(}|).*'/;
 

--- a/checks/valid-json-arrays-in-bash.js
+++ b/checks/valid-json-arrays-in-bash.js
@@ -66,7 +66,7 @@ export ${variableName}='[${tokens}]'
           results.push({
             title: `${variableName} does not parse`,
             problems: [
-              `The contents of the ${variableName} variable must contain valid JSON.`
+              `The contents of the ${variableName} variable must contain valid stringified JSON.`
             ],
             line: lineNumber,
             level: "failure",

--- a/checks/valid-json-arrays-in-bash.js
+++ b/checks/valid-json-arrays-in-bash.js
@@ -19,7 +19,7 @@ async function validJsonArrayInBash(deployment, context, inputs, httpGet) {
     log.info(`No Orders Present - Skipping ${deployment.serviceName}`);
     return [];
   }
-  log.info(`Template Check - ${deployment.ordersPath}`);
+  log.info(`CMD/ENTRYPOINT are valid JSON - ${deployment.ordersPath}`);
 
   /** @type {Array<Result>} */
   const results = [];

--- a/checks/valid-json-arrays-in-bash.js
+++ b/checks/valid-json-arrays-in-bash.js
@@ -45,7 +45,7 @@ async function validJsonArrayInBash(deployment, context, inputs, httpGet) {
           let suggestion = "";
 
           if (obj.constructor.name === "String") {
-            // attempt a solution for them.
+            // Try to convert string into valid json array
             const tokens = obj.split(/\s+/).map(s=>`"${s}"`).join(",");
             suggestion = `\`\`\`suggestion
 export ${variableName}='[${tokens}]'

--- a/checks/valid-json-arrays-in-bash.js
+++ b/checks/valid-json-arrays-in-bash.js
@@ -1,0 +1,84 @@
+require("../typedefs");
+const log = require("loglevel");
+
+/**
+ * Accepts a deployment object, and checks that any CMD or ENTRYPOINT variables
+*  are correctly structured.
+ * @param {Deployment} deployment An object containing information about a deployment
+ * @param {GitHubContext} context The context object provided by github
+ * @param {ActionInputs} inputs The inputs (excluding the token) from the github action
+ * @param {function(string, (object | undefined)):Promise} httpGet
+ *
+ * @returns {Array<Result>}
+ */
+async function validJsonArrayInBash(deployment, context, inputs, httpGet) {
+  /**
+   * You should check the existance of any file you're trying to check
+   */
+  if (!deployment.ordersContents) {
+    log.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
+  log.info(`Template Check - ${deployment.ordersPath}`);
+
+  /** @type {Array<Result>} */
+  const results = [];
+
+  deployment.ordersContents.forEach((line, i) => {
+    // GitHub lines are 1-indexed
+    const lineNumber = i + 1;
+    // this test only checks CMD and ENTRYPOINT values
+    const r = line.match(/export\s+(CMD|ENTRYPOINT)=(['"])(.*)\2/);
+
+    if (r) {
+      // get value of CMD variable
+      const variableName = r[1];
+      //const quoteStyle = (r[2] == '\'' ? 'single' : 'double');
+      const value = r[3];
+
+      try {
+        // Is value valid JSON?
+        const obj = JSON.parse(value);
+
+        // it is JSON, but is it an array?
+        if (obj.constructor.name !== "Array") {
+          let suggestion = "";
+
+          if (obj.constructor.name === "String") {
+            // attempt a solution for them.
+            const tokens = obj.split(/\s+/).map(s=>`"${s}"`).join(",");
+            suggestion = `\`\`\`suggestion
+export ${variableName}='[${tokens}]'
+\`\`\``;
+          }
+
+          results.push({
+            title: `${variableName} is not a JSON Array`,
+            problems: [
+              `The contents of the ${variableName} variable must contain a valid JSON Array.\n${suggestion}`
+            ],
+            line: lineNumber,
+            level: "failure",
+          });
+        }
+      } catch (e) {
+        if (e instanceof SyntaxError) {
+          results.push({
+            title: `${variableName} does not parse`,
+            problems: [
+              `The contents of the ${variableName} variable must contain valid JSON.`
+            ],
+            line: lineNumber,
+            level: "failure",
+          });
+        } else {
+          throw e;
+        }
+      }
+    }
+  });
+
+  return results;
+}
+
+module.exports = validJsonArrayInBash;

--- a/checks/valid-json-arrays-in-bash.js
+++ b/checks/valid-json-arrays-in-bash.js
@@ -31,9 +31,8 @@ async function validJsonArrayInBash(deployment, context, inputs, httpGet) {
     const r = line.match(/export\s+(CMD|ENTRYPOINT)=(['"])(.*)\2/);
 
     if (r) {
-      // get value of CMD variable
+      // get value and name of the variable
       const variableName = r[1];
-      //const quoteStyle = (r[2] == '\'' ? 'single' : 'double');
       const value = r[3];
 
       try {
@@ -41,14 +40,14 @@ async function validJsonArrayInBash(deployment, context, inputs, httpGet) {
         const obj = JSON.parse(value);
 
         // it is JSON, but is it an array?
-        if (obj.constructor.name !== "Array") {
+        if (!Array.isArray(obj)) {
           let suggestion = "";
 
-          if (obj.constructor.name === "String") {
+          if (typeof obj === "string") {
             // Try to convert string into valid json array
-            const tokens = obj.split(/\s+/).map(s=>`"${s}"`).join(",");
+            const newArray = JSON.stringify(obj.split(/\s+/));
             suggestion = `\`\`\`suggestion
-export ${variableName}='[${tokens}]'
+export ${variableName}='${newArray}'
 \`\`\``;
           }
 

--- a/test/entrypoint-requires-cmd.js
+++ b/test/entrypoint-requires-cmd.js
@@ -1,0 +1,69 @@
+const { expect } = require("chai");
+const entrypointRequiresCmdCheck = require("../checks/entrypoint-requires-cmd");
+
+describe("Valid JSON Arrays in Bash Checker", async () => {
+  it("skips if therea is no orders file", async () => {
+    const deployment = {
+      serviceName: "streamliner"
+    };
+
+    const results = await entrypointRequiresCmdCheck(deployment);
+    expect(results.length).to.equal(0);
+  });
+
+  it("ignores variables not named CMD or ENTRYPOINT", async () => {
+    const result = await entrypointRequiresCmdCheck({
+      serviceName: "catpants",
+      ordersPath: "catpants/orders",
+      ordersContents: [
+        'export NOTCMD=\'["npm", "run", "start\'',
+        'export NOTENTRYPOINT=\'["./establish-lock.sh"]\''
+      ],
+    });
+
+    expect(result).to.have.lengthOf(0);
+  });
+
+  it("accepts CMD alone is valid", async () => {
+    const result = await entrypointRequiresCmdCheck({
+      serviceName: "catpants",
+      ordersPath: "catpants/orders",
+      ordersContents: [
+        'export CMD=\'["npm", "run", "start"]\'',
+        'export NOTENTRYPOINT=\'["./establish-lock.sh"]\''
+      ],
+    });
+
+    expect(result).to.have.lengthOf(0);
+  });
+
+  it("accepts CMD and ENTRYPOINT together is valid", async () => {
+    const result = await entrypointRequiresCmdCheck({
+      serviceName: "catpants",
+      ordersPath: "catpants/orders",
+      ordersContents: [
+        'export CMD=\'["npm", "run", "start]\'',
+        'export ENTRYPOINT=\'["./establish-lock.sh"]\''
+      ],
+    });
+
+    expect(result).to.have.lengthOf(0);
+  });
+
+  it("rejects ENTRYPOINT without CMD", async () => {
+    const results = await entrypointRequiresCmdCheck({
+      serviceName: "catpants",
+      ordersPath: "catpants/orders",
+      ordersContents: [
+        'export ENTRYPOINT=\'["./establish-lock.sh"]\''
+      ],
+    });
+
+    expect(results.length).to.equal(1);
+    expect(results[0].problems[0]).to.equal(
+      `Using ENTRYPOINT to override the docker image requires that you also override CMD.\nSee https://docs.docker.com/engine/reference/run/#entrypoint-default-command-to-execute-at-runtime`
+    );
+
+  });
+
+});

--- a/test/valid-bash-substitution.js
+++ b/test/valid-bash-substitution.js
@@ -38,6 +38,18 @@ describe("Valid Bash Substitution Checker", async () => {
     expect(result).to.have.lengthOf(0);
   });
 
+  it("ignores ENTRYPOINT bash subsitutions", async () => {
+    const result = await validSubstitutionCheck({
+      serviceName: "catpants",
+      ordersPath: "catpants/orders",
+      ordersContents: [
+        'export ENTRYPOINT=\'["bash", "-c", "source /catpants; echo $CAT + $PANTS" = glorious"]\''
+      ],
+    });
+
+    expect(result).to.have.lengthOf(0);
+  });
+
   it("rejects bash subsitutions contained in single quotes", async () => {
     let deployment = {
       serviceName: "streamliner",

--- a/test/valid-json-arrays-in-bash.js
+++ b/test/valid-json-arrays-in-bash.js
@@ -1,0 +1,118 @@
+const { expect } = require("chai");
+const validJsonArrayInBashCheck = require("../checks/valid-json-arrays-in-bash");
+
+describe("Valid JSON Arrays in Bash Checker", async () => {
+  it("skips if therea is no orders file", async () => {
+    const deployment = {
+      serviceName: "streamliner"
+    };
+
+    const results = await validJsonArrayInBashCheck(deployment);
+    expect(results.length).to.equal(0);
+  });
+
+  it("ignores variables not named CMD or ENTRYPOINT", async () => {
+    const result = await validJsonArrayInBashCheck({
+      serviceName: "catpants",
+      ordersPath: "catpants/orders",
+      ordersContents: [
+        'export NOTCMD=\'["npm", "run", "start\''
+      ],
+    });
+
+    expect(result).to.have.lengthOf(0);
+  });
+
+  it("accepts valid arrays in CMD bash variables", async () => {
+    const result = await validJsonArrayInBashCheck({
+      serviceName: "catpants",
+      ordersPath: "catpants/orders",
+      ordersContents: [
+        'export CMD=\'["npm", "run", "start"]\''
+      ],
+    });
+
+    expect(result).to.have.lengthOf(0);
+  });
+
+  it("rejects invalid JSON in CMD bash variables", async () => {
+    const results = await validJsonArrayInBashCheck({
+      serviceName: "catpants",
+      ordersPath: "catpants/orders",
+      ordersContents: [
+        'export CMD=\'["npm", "run", "start]\''
+      ],
+    });
+
+    expect(results.length).to.equal(1);
+    expect(results[0].problems[0]).to.equal(
+      `The contents of the CMD variable must contain valid JSON.`
+    );
+
+  });
+
+  it("rejects invalid JSON array in CMD bash variables", async () => {
+    const results = await validJsonArrayInBashCheck({
+      serviceName: "catpants",
+      ordersPath: "catpants/orders",
+      ordersContents: [
+        'export CMD=\'"npm start"\''
+      ],
+    });
+
+    expect(results.length).to.equal(1);
+    expect(results[0].problems[0]).to.equal(
+      `The contents of the CMD variable must contain a valid JSON Array.\n\`\`\`suggestion
+export CMD='["npm","start"]'
+\`\`\``
+    );
+
+  });
+
+  it("accepts valid arrays in ENTRYPOINT bash variables", async () => {
+    const result = await validJsonArrayInBashCheck({
+      serviceName: "catpants",
+      ordersPath: "catpants/orders",
+      ordersContents: [
+        'export ENTRYPOINT=\'["./establish-lock.sh"]\''
+      ],
+    });
+
+    expect(result).to.have.lengthOf(0);
+  });
+
+  it("rejects invalid JSON in ENTRYPOINT bash variables", async () => {
+    const results = await validJsonArrayInBashCheck({
+      serviceName: "catpants",
+      ordersPath: "catpants/orders",
+      ordersContents: [
+        'export ENTRYPOINT=\'["establish-lock.sh]\''
+      ],
+    });
+
+    expect(results.length).to.equal(1);
+    expect(results[0].problems[0]).to.equal(
+      `The contents of the ENTRYPOINT variable must contain valid JSON.`
+    );
+
+  });
+
+  it("rejects invalid JSON array in ENTRYPOINT bash variables", async () => {
+    const results = await validJsonArrayInBashCheck({
+      serviceName: "catpants",
+      ordersPath: "catpants/orders",
+      ordersContents: [
+        'export ENTRYPOINT=\'"./establish-lock.sh"\''
+      ],
+    });
+
+    expect(results.length).to.equal(1);
+    expect(results[0].problems[0]).to.equal(
+      `The contents of the ENTRYPOINT variable must contain a valid JSON Array.\n\`\`\`suggestion
+export ENTRYPOINT='["./establish-lock.sh"]'
+\`\`\``
+    );
+
+  });
+
+});

--- a/test/valid-json-arrays-in-bash.js
+++ b/test/valid-json-arrays-in-bash.js
@@ -1,118 +1,74 @@
 const { expect } = require("chai");
 const validJsonArrayInBashCheck = require("../checks/valid-json-arrays-in-bash");
 
-describe("Valid JSON Arrays in Bash Checker", async () => {
-  it("skips if therea is no orders file", async () => {
-    const deployment = {
-      serviceName: "streamliner"
-    };
+["CMD", "ENTRYPOINT"].map(varName => {
+  describe(`Valid JSON Arrays in Bash Checker - ${varName}`, async () => {
+    it("skips if therea is no orders file", async () => {
+      const deployment = {
+        serviceName: "streamliner"
+      };
 
-    const results = await validJsonArrayInBashCheck(deployment);
-    expect(results.length).to.equal(0);
-  });
-
-  it("ignores variables not named CMD or ENTRYPOINT", async () => {
-    const result = await validJsonArrayInBashCheck({
-      serviceName: "catpants",
-      ordersPath: "catpants/orders",
-      ordersContents: [
-        'export NOTCMD=\'["npm", "run", "start\''
-      ],
+      const results = await validJsonArrayInBashCheck(deployment);
+      expect(results.length).to.equal(0);
     });
 
-    expect(result).to.have.lengthOf(0);
-  });
+    it(`ignores variables not named ${varName}`, async () => {
+      const result = await validJsonArrayInBashCheck({
+        serviceName: "catpants",
+        ordersPath: "catpants/orders",
+        ordersContents: [
+          `export NOT${varName}=\'["npm", "run", "start\'`
+        ],
+      });
 
-  it("accepts valid arrays in CMD bash variables", async () => {
-    const result = await validJsonArrayInBashCheck({
-      serviceName: "catpants",
-      ordersPath: "catpants/orders",
-      ordersContents: [
-        'export CMD=\'["npm", "run", "start"]\''
-      ],
+      expect(result).to.have.lengthOf(0);
     });
 
-    expect(result).to.have.lengthOf(0);
-  });
+    it(`accepts valid arrays in ${varName} bash variables`, async () => {
+      const result = await validJsonArrayInBashCheck({
+        serviceName: "catpants",
+        ordersPath: "catpants/orders",
+        ordersContents: [
+          `export ${varName}=\'["npm", "run", "start"]\'`
+        ],
+      });
 
-  it("rejects invalid JSON in CMD bash variables", async () => {
-    const results = await validJsonArrayInBashCheck({
-      serviceName: "catpants",
-      ordersPath: "catpants/orders",
-      ordersContents: [
-        'export CMD=\'["npm", "run", "start]\''
-      ],
+      expect(result).to.have.lengthOf(0);
     });
 
-    expect(results.length).to.equal(1);
-    expect(results[0].problems[0]).to.equal(
-      `The contents of the CMD variable must contain valid JSON.`
-    );
+    it(`rejects invalid JSON in ${varName} bash variables`, async () => {
+      const results = await validJsonArrayInBashCheck({
+        serviceName: "catpants",
+        ordersPath: "catpants/orders",
+        ordersContents: [
+          `export ${varName}=\'["npm", "run", "start]\'`
+        ],
+      });
 
-  });
+      expect(results.length).to.equal(1);
+      expect(results[0].problems[0]).to.equal(
+        `The contents of the ${varName} variable must contain valid JSON.`
+      );
 
-  it("rejects invalid JSON array in CMD bash variables", async () => {
-    const results = await validJsonArrayInBashCheck({
-      serviceName: "catpants",
-      ordersPath: "catpants/orders",
-      ordersContents: [
-        'export CMD=\'"npm start"\''
-      ],
     });
 
-    expect(results.length).to.equal(1);
-    expect(results[0].problems[0]).to.equal(
-      `The contents of the CMD variable must contain a valid JSON Array.\n\`\`\`suggestion
-export CMD='["npm","start"]'
+    it(`rejects invalid JSON array in ${varName} bash variables`, async () => {
+      const results = await validJsonArrayInBashCheck({
+        serviceName: "catpants",
+        ordersPath: "catpants/orders",
+        ordersContents: [
+          `export ${varName}=\'"npm start"\'`
+        ],
+      });
+
+      expect(results.length).to.equal(1);
+      expect(results[0].problems[0]).to.equal(
+        `The contents of the ${varName} variable must contain a valid JSON Array.\n\`\`\`suggestion
+export ${varName}='["npm","start"]'
 \`\`\``
-    );
+      );
 
-  });
-
-  it("accepts valid arrays in ENTRYPOINT bash variables", async () => {
-    const result = await validJsonArrayInBashCheck({
-      serviceName: "catpants",
-      ordersPath: "catpants/orders",
-      ordersContents: [
-        'export ENTRYPOINT=\'["./establish-lock.sh"]\''
-      ],
     });
 
-    expect(result).to.have.lengthOf(0);
   });
-
-  it("rejects invalid JSON in ENTRYPOINT bash variables", async () => {
-    const results = await validJsonArrayInBashCheck({
-      serviceName: "catpants",
-      ordersPath: "catpants/orders",
-      ordersContents: [
-        'export ENTRYPOINT=\'["establish-lock.sh]\''
-      ],
-    });
-
-    expect(results.length).to.equal(1);
-    expect(results[0].problems[0]).to.equal(
-      `The contents of the ENTRYPOINT variable must contain valid JSON.`
-    );
-
-  });
-
-  it("rejects invalid JSON array in ENTRYPOINT bash variables", async () => {
-    const results = await validJsonArrayInBashCheck({
-      serviceName: "catpants",
-      ordersPath: "catpants/orders",
-      ordersContents: [
-        'export ENTRYPOINT=\'"./establish-lock.sh"\''
-      ],
-    });
-
-    expect(results.length).to.equal(1);
-    expect(results[0].problems[0]).to.equal(
-      `The contents of the ENTRYPOINT variable must contain a valid JSON Array.\n\`\`\`suggestion
-export ENTRYPOINT='["./establish-lock.sh"]'
-\`\`\``
-    );
-
-  });
-
 });

--- a/test/valid-json-arrays-in-bash.js
+++ b/test/valid-json-arrays-in-bash.js
@@ -47,7 +47,7 @@ const validJsonArrayInBashCheck = require("../checks/valid-json-arrays-in-bash")
 
       expect(results.length).to.equal(1);
       expect(results[0].problems[0]).to.equal(
-        `The contents of the ${varName} variable must contain valid JSON.`
+        `The contents of the ${varName} variable must contain valid stringified JSON.`
       );
 
     });


### PR DESCRIPTION
This checks that CMD and ENTRYPOINT parse as JSON and contain parse as an Array.

It will present the following errors (and opts out of some other checks where these provide more appropriate messaging):

Parses as a string:
![image](https://user-images.githubusercontent.com/5762261/149591782-6b471eb4-8eb7-416a-b454-9ff7ee629966.png)

Does not parse as JSON:
![image](https://user-images.githubusercontent.com/5762261/149591817-fcfcbf51-f366-460b-8e75-91803b750bbc.png)

ENTRYPOINT present without CMD:
![image](https://user-images.githubusercontent.com/5762261/149591864-fa8bab1f-a27e-4d6a-9c4e-dd3ac0f45eb2.png)

