### PR TITLE
make dupe exports a warning

### DIFF
--- a/checks/no-duplicate-exports.js
+++ b/checks/no-duplicate-exports.js
@@ -61,7 +61,7 @@ async function noDuplicateExports(deployment) {
           ].join(", ")}**`,
         ],
         line: i + 1,
-        level: "failure",
+        level: "warning",
       };
 
       results.push(result);

--- a/test/no-duplicate-exports.js
+++ b/test/no-duplicate-exports.js
@@ -4,7 +4,7 @@ const noDupes = require("../checks/no-duplicate-exports");
 describe("No Duplicate Exports Check", () => {
   it("skips if there is no orders file", async () => {
     const deployment = {
-      serviceName: "streamliner"
+      serviceName: "streamliner",
     };
 
     const results = await noDupes(deployment);
@@ -19,7 +19,7 @@ describe("No Duplicate Exports Check", () => {
         "export THREE=something",
         "export UNIQUE=123",
         'export VARS="quoted string"',
-        "dockerdeploy github/glg/streamliner/main:latest"
+        "dockerdeploy github/glg/streamliner/main:latest",
       ],
     };
 
@@ -28,7 +28,7 @@ describe("No Duplicate Exports Check", () => {
     expect(results.length).to.equal(0);
   });
 
-  it("rejects orders that contain duplicate exports", async () => {
+  it("warns for orders that contain duplicate exports", async () => {
     const deployment = {
       serviceName: "streamliner",
       ordersPath: "streamliner/orders",
@@ -46,9 +46,11 @@ describe("No Duplicate Exports Check", () => {
     expect(results[0].problems[0]).to.equal(
       "The variable `DUPED` is exported on multiple lines: **1, 2**"
     );
+    expect(results[0].level).to.equal("warning");
 
     expect(results[1].problems[0]).to.equal(
       "The variable `DUPED` is exported on multiple lines: **1, 2**"
     );
+    expect(results[1].level).to.equal("warning");
   });
 });


### PR DESCRIPTION
resolves #141 

Ambrose brings up a valid point that duplicate exports should not be a failing check, since it is technically valid bash. So, downgrading this to a "warning" level check.