### PR TITLE
Issue147

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ This is a github action for validating PRs to GDS Cluster Configs. It evaluates 
     - [restrictedBuckets](#restrictedbuckets)
     - [validBetas](#validbetas)
     - [shellcheck](#shellcheck)
-    - [validJsonArraysInBash](#validJsonarraysinbash)
+    - [validJsonArraysInBash](#validjsonarraysinbash)
     - [entrypointRequiresCmd](#entrypointrequirescmd)
     - [noDuplicateForwardHostHeaders](#noduplicateforwardhostheaders)
+    - [JobsShouldUseBulkMail](#jobsshouldusebulkmail)
   - [Adding Checks](#adding-checks)
+    - [Testing locally](#testing-locally)
   - [Who's the goat?](#whos-the-goat)
 
 ## Why are node_modules checked in?
@@ -245,6 +247,9 @@ Runs the [shellcheck](https://github.com/koalaman/shellcheck) utility on the ord
 ### noDuplicateForwardHostHeaders
 
 - Each FORWARD_HOST_HEADERS value must be unique for a cluster config. Otherwise, AWS will throw errors about the duplicates and possibly leave your load balancer in a broken state.
+
+### JobsShouldUseBulkMail
+- jobs should prefer bulkmail-internal to email-internal
 
 ## Adding Checks
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a github action for validating PRs to GDS Cluster Configs. It evaluates 
   - [Why are node_modules checked in?](#why-are-node_modules-checked-in)
   - [Why review comments and not checks api?](#why-review-comments-and-not-checks-api)
   - [Example Usage:](#example-usage)
+  - [Configuration](#configuration)
   - [Checks](#checks)
     - [serviceName](#servicename)
     - [deploymentLine](#deploymentline)
@@ -74,6 +75,30 @@ jobs:
       - uses: glg-public/gds-cc-screamer@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Configuration
+
+You can add further, more granular configuration through the use of `.ccscreamer.json`. This file lives at the root of a cluster config repository, and provides a mechanism to customize behavior on a per-service and per-check level.
+
+Currently supported overrides are:
+- `maxLevel`: Defines the maximum level a specific check can return for a specific service: "success", "notice", "warning", "failure"
+- `skip`: Ignore results for this check for this service
+
+The file looks like
+```json
+{
+  "service-name": {
+    "checkName": {
+      "skip": true
+    }
+  },
+  "service-name2": {
+    "checkName": {
+      "maxLevel": "warning"
+    }
+  }
+}
 ```
 
 ## Checks

--- a/checks/index.js
+++ b/checks/index.js
@@ -29,8 +29,9 @@ const restrictedBuckets = require("./restricted-buckets");
 const doubleQuotes = require("./double-quotes");
 const validBetas = require("./valid-betas");
 const shellcheck = require("./shellcheck");
-const validJsonArraysInBashCheck = require("./valid-json-arrays-in-bash")
+const validJsonArraysInBashCheck = require("./valid-json-arrays-in-bash");
 const entrypointRequiresCmdCheck = require("./entrypoint-requires-cmd");
+const jobsShouldUseBulkMail = require("./jobs-should-use-bulkmail");
 
 /**
  * Exports all checks in an appropriate order
@@ -67,6 +68,7 @@ module.exports = {
   shellcheck,
   validJsonArraysInBashCheck,
   entrypointRequiresCmdCheck,
+  jobsShouldUseBulkMail,
 
   /**
    *  This should always be after checks for orders and secrets.json, because it verifies that the

--- a/checks/jobs-should-use-bulkmail.js
+++ b/checks/jobs-should-use-bulkmail.js
@@ -1,0 +1,35 @@
+require("../typedefs");
+const log = require("loglevel");
+
+/**
+ * Accepts a deployment object, and does some kind of check
+ * @param {Deployment} deployment An object containing information about a deployment
+ * @param {GitHubContext} context The context object provided by github
+ * @param {ActionInputs} inputs The inputs (excluding the token) from the github action
+ * @param {function(string, (object | undefined)):Promise} httpGet
+ *
+ * @returns {Array<Result>}
+ */
+async function jobsShouldUseBulkMail(deployment, context, inputs, httpGet) {
+  /**
+   * You should check the existance of any file you're trying to check
+   */
+  if (!deployment.ordersContents) {
+    log.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
+  log.info(`Jobs Should Use Bulkmail - ${deployment.ordersPath}`);
+
+  /** @type {Array<Result>} */
+  const results = [];
+
+  deployment.ordersContents.forEach((line, i) => {
+    // GitHub lines are 1-indexed
+    const lineNumber = i + 1;
+    // do something
+  });
+
+  return results;
+}
+
+module.exports = jobsShouldUseBulkMail;

--- a/test/fixtures/jobs-cc1/.ccscreamer.json
+++ b/test/fixtures/jobs-cc1/.ccscreamer.json
@@ -1,0 +1,10 @@
+{
+  "service1": {
+    "check-name1": {
+      "maxLevel": "warning"
+    },
+    "check-name2": {
+      "skip": true
+    }
+  }
+}

--- a/test/jobs-should-use-bulkmail.js
+++ b/test/jobs-should-use-bulkmail.js
@@ -3,9 +3,40 @@ const { expect } = require("chai");
 const jobsShouldUseBulkMail = require("../checks/jobs-should-use-bulkmail");
 
 describe("jobsShouldUseBulkMail", () => {
-  it("skips if there are no orders");
+  it("skips if there are no orders", async () => {
+    const deployment = {
+      serviceName: "fake",
+    };
 
-  it("skips if deployment is not a job");
+    const results = await jobsShouldUseBulkMail(deployment);
+    expect(results.length).to.equal(0);
+  });
 
-  it("suggests replacing email-internal with bulkmail-internal");
+  it("skips if deployment is not a job", async () => {
+    const deployment = {
+      serviceName: "fake",
+      ordersContents: ["dockerdeploy github/glg/echo/gds:latest"],
+    };
+
+    const results = await jobsShouldUseBulkMail(deployment);
+    expect(results.length).to.equal(0);
+  });
+
+  it("suggests replacing email-internal with bulkmail-internal", async () => {
+    const deployment = {
+      serviceName: "fake",
+      ordersContents: [
+        "jobdeploy github/glg/echo/gds:latest",
+        'export SMTP_SERVER="email-internal.glgresearch.com"',
+      ],
+    };
+
+    const results = await jobsShouldUseBulkMail(deployment);
+    expect(results.length).to.equal(1);
+    expect(results[0].line).to.equal(2);
+    expect(results[0].level).to.equal("failure");
+    expect(results[0].problems[0]).to.match(
+      /```suggestion\s+.+bulkmail-internal\.glgresearch\.com.*\s+```/
+    );
+  });
 });

--- a/test/jobs-should-use-bulkmail.js
+++ b/test/jobs-should-use-bulkmail.js
@@ -1,0 +1,11 @@
+const { expect } = require("chai");
+
+const jobsShouldUseBulkMail = require("../checks/jobs-should-use-bulkmail");
+
+describe("jobsShouldUseBulkMail", () => {
+  it("skips if there are no orders");
+
+  it("skips if deployment is not a job");
+
+  it("suggests replacing email-internal with bulkmail-internal");
+});

--- a/test/util/generic.js
+++ b/test/util/generic.js
@@ -10,9 +10,11 @@ const {
   getMaskComponents,
   getSimpleSecret,
   applyConfig,
+  parseEnvVar,
 } = require("../../util/generic");
 const roles = require("../fixtures/roles");
 const ccConfig = require("../fixtures/jobs-cc1/.ccscreamer.json");
+const { env } = require("process");
 
 describe("isAJob", () => {
   it("takes file lines, and determines if it is a job deployment", () => {
@@ -255,5 +257,43 @@ describe("applyConfig", () => {
         level: "warning",
       },
     ]);
+  });
+});
+
+describe("parseEnvVar", () => {
+  it("returns an empty object if a line doesn't define an environment variable", () => {
+    const obj = parseEnvVar("# this line is just a comment");
+
+    expect(obj).to.deep.equal({});
+  });
+
+  it("works with single quoted", () => {
+    const envvar = parseEnvVar("export CAT='pants'");
+
+    expect(envvar).to.deep.equal({
+      exported: true,
+      name: "CAT",
+      value: "pants",
+    });
+  });
+
+  it("works with double quoted", () => {
+    const envvar = parseEnvVar('export CAT="pants"');
+
+    expect(envvar).to.deep.equal({
+      exported: true,
+      name: "CAT",
+      value: "pants",
+    });
+  });
+
+  it("works with unexported", () => {
+    const envvar = parseEnvVar('CAT="pants"');
+
+    expect(envvar).to.deep.equal({
+      exported: false,
+      name: "CAT",
+      value: "pants",
+    });
   });
 });

--- a/util/generic.js
+++ b/util/generic.js
@@ -428,6 +428,20 @@ function applyConfig({ config, serviceName, checkName, results }) {
   }
 }
 
+const envvar = /^(export\s+|)(\w+)=['"](.+)['"]/;
+function parseEnvVar(line) {
+  const match = envvar.exec(line);
+  if (match) {
+    const [, exported, name, value] = match;
+    return {
+      exported: !!exported,
+      name,
+      value,
+    };
+  }
+  return {};
+}
+
 module.exports = {
   isAJob,
   getContents,
@@ -443,4 +457,5 @@ module.exports = {
   getAccess,
   getClusterType,
   applyConfig,
+  parseEnvVar,
 };

--- a/util/index.js
+++ b/util/index.js
@@ -36,6 +36,7 @@ const {
   getRoleByClaim,
   getClusterType,
   applyConfig,
+  parseEnvVar,
 } = require("./generic");
 
 module.exports = {
@@ -70,4 +71,5 @@ module.exports = {
   getRoleByClaim,
   getClusterType,
   applyConfig,
+  parseEnvVar,
 };

--- a/util/index.js
+++ b/util/index.js
@@ -35,6 +35,7 @@ const {
   getMaskComponents,
   getRoleByClaim,
   getClusterType,
+  applyConfig,
 } = require("./generic");
 
 module.exports = {
@@ -68,4 +69,5 @@ module.exports = {
   getMaskComponents,
   getRoleByClaim,
   getClusterType,
+  applyConfig,
 };


### PR DESCRIPTION
resolves #147 

## New Check

There is a new check that suggests replacing "email-internal.glgresearch.com" with "bulkmail-internal.glgresearch.com"

## New Functionality

cc screamer now looks for a config file at `./.ccscreamer.json`, which allows customized behavior per-service/per-check.

The file looks like
```json
{
  "service-name": {
    "checkName": {
      "skip": true
    }
  },
  "service-name2": {
    "checkName": {
      "maxLevel": "warning"
    }
  }
}
```