### PR TITLE
always specify path, even though we default it in some places

### DIFF
--- a/checks/deployment-line.js
+++ b/checks/deployment-line.js
@@ -209,6 +209,7 @@ async function validateDeploymentLine(deployment, context, inputs, httpGet) {
   return [
     {
       title,
+      path: deployment.ordersPath,
       problems,
       line: lineNumber,
       level,

--- a/checks/entrypoint-requires-cmd.js
+++ b/checks/entrypoint-requires-cmd.js
@@ -31,19 +31,19 @@ async function entrypointRequiresCmd(deployment, context, inputs, httpGet) {
     const lineNumber = i + 1;
     // this test only checks CMD and ENTRYPOINT values
     hasCmd = /export\s+CMD/.test(line) || hasCmd;
-    const thisLineHasEntrypoint = /export\s+ENTRYPOINT/.test(line)
+    const thisLineHasEntrypoint = /export\s+ENTRYPOINT/.test(line);
     hasEntrypoint = thisLineHasEntrypoint || hasEntrypoint;
     if (thisLineHasEntrypoint) {
       entrypointLineNo = lineNumber;
     }
-
   });
 
   if (hasEntrypoint && !hasCmd) {
     results.push({
       title: `ENTRYPOINT requires CMD`,
+      path: deployment.ordersPath,
       problems: [
-        `Using ENTRYPOINT to override the docker image requires that you also override CMD.\nSee https://docs.docker.com/engine/reference/run/#entrypoint-default-command-to-execute-at-runtime`
+        `Using ENTRYPOINT to override the docker image requires that you also override CMD.\nSee https://docs.docker.com/engine/reference/run/#entrypoint-default-command-to-execute-at-runtime`,
       ],
       line: entrypointLineNo,
       level: "failure",

--- a/checks/healthcheck.js
+++ b/checks/healthcheck.js
@@ -61,6 +61,7 @@ async function validateHealthcheck(deployment) {
   return [
     {
       title: "Invalid Healthcheck",
+      path: deployment.ordersPath,
       problems,
       line: lineNumber,
       level: "failure",

--- a/checks/https-only.js
+++ b/checks/https-only.js
@@ -30,6 +30,7 @@ async function httpsOnly(deployment) {
     if (reBadURLs.test(line)) {
       const result = {
         title: "HTTPS Only",
+        path: deployment.ordersPath,
         problems: [
           `Use HTTPS for all requests to GLG domains\n\`\`\`suggestion
 ${line.replace(/http:/i, "https:")}

--- a/checks/no-duplicate-exports.js
+++ b/checks/no-duplicate-exports.js
@@ -55,6 +55,7 @@ async function noDuplicateExports(deployment) {
     if (counts[variable] && counts[variable] > 1) {
       const result = {
         title: "Duplicate Export",
+        path: deployment.ordersPath,
         problems: [
           `The variable \`${variable}\` is exported on multiple lines: **${lines[
             variable

--- a/checks/no-sourcing.js
+++ b/checks/no-sourcing.js
@@ -23,6 +23,7 @@ async function noSourcing(deployment) {
     if (sourceUse.test(line)) {
       results.push({
         title: "No Use of `source`",
+        path: deployment.ordersPath,
         problems: [
           "You should not source any other files in your orders files.",
         ],

--- a/checks/no-spaces-in-exports.js
+++ b/checks/no-spaces-in-exports.js
@@ -30,6 +30,7 @@ async function noSpacesInExports(deployment) {
       const { variable, value } = match.groups;
       results.push({
         title: "No Spaces in Exports",
+        path: deployment.ordersPath,
         problems: [
           `Trim out this whitespace\n\`\`\`suggestion
 export ${variable}=${value}

--- a/checks/valid-bash-substitution.js
+++ b/checks/valid-bash-substitution.js
@@ -25,6 +25,7 @@ async function validBashSubsitutions(deployment) {
     if (match && !EXCLUDED_VARIABLE_NAMES.includes(match.groups.variable)) {
       results.push({
         title: "Bad Substitution",
+        path: deployment.ordersPath,
         problems: [
           `You must use double quotes for bash subsitutions.\n\`\`\`suggestion
 ${line.replace(/'/g, '"')}

--- a/util/github.js
+++ b/util/github.js
@@ -140,7 +140,7 @@ async function leaveComment(
           ? result.line
           : `${result.line.start} - ${result.line.end}`;
       result.problems.unshift(
-        `Problem existed outside of diff at \`${result.path}\`, line **${line}**`
+        `Problem existed outside of diff at \`${resultPath}\`, line **${line}**`
       );
       result.line = 0;
       await leaveComment(octokit, deployment, result, {


### PR DESCRIPTION
resolves #149, which occurs because  in every other place, we default path to orders path, but not in the case of problems existing outside of diff. I added a default, and made several checks more explicit