### PR TITLE
Add a check that locks by fqdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ This is a github action for validating PRs to GDS Cluster Configs. It evaluates 
     - [validJsonArraysInBash](#validjsonarraysinbash)
     - [entrypointRequiresCmd](#entrypointrequirescmd)
     - [noDuplicateForwardHostHeaders](#noduplicateforwardhostheaders)
-    - [JobsShouldUseBulkMail](#jobsshouldusebulkmail)
+    - [jobsShouldUseBulkMail](#jobsshouldusebulkmail)
+    - [fqdnLock](#fqdnlock)
   - [Adding Checks](#adding-checks)
     - [Testing locally](#testing-locally)
   - [Who's the goat?](#whos-the-goat)
@@ -273,8 +274,12 @@ Runs the [shellcheck](https://github.com/koalaman/shellcheck) utility on the ord
 
 - Each FORWARD_HOST_HEADERS value must be unique for a cluster config. Otherwise, AWS will throw errors about the duplicates and possibly leave your load balancer in a broken state.
 
-### JobsShouldUseBulkMail
+### jobsShouldUseBulkMail
 - jobs should prefer bulkmail-internal to email-internal
+
+
+### fqdnLock
+- if `fqdn_locks` is configured and the deployment references that fqdn, it will be blocked
 
 ## Adding Checks
 

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,10 @@ inputs:
     description: The repository where epiquery templates are kept.
     required: false
     default: glg/epiquery-templates
+  fqdn_locks:
+    description: A comma separated list of FQDNs that should be blocked from deploying
+    required: false
+    default: ""
 runs:
   using: "node16"
   main: "index.js"

--- a/checks/fqdn-lock.js
+++ b/checks/fqdn-lock.js
@@ -1,0 +1,45 @@
+require("../typedefs");
+const log = require("loglevel");
+const { getExportValue } = require("../util");
+
+/**
+ * Accepts a deployment object, and does some kind of check
+ * @param {Deployment} deployment An object containing information about a deployment
+ * @param {GitHubContext} context The context object provided by github
+ * @param {ActionInputs} inputs The inputs (excluding the token) from the github action
+ * @param {function(string, (object | undefined)):Promise} httpGet
+ *
+ * @returns {Array<Result>}
+ */
+async function fqdnLock(deployment, context, inputs, httpGet) {
+  if (!inputs.fqdnLocks || inputs.fqdnLocks.size === 0) {
+    log.info(`No FQDN Locks configured. Skipping.`);
+    return [];
+  }
+
+  if (!deployment.ordersContents) {
+    log.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
+
+  log.info(`FQDN Lock - ${deployment.ordersPath}`);
+
+  const fqdn = getExportValue(deployment.ordersContents.join("\n"), "GDS_FQDN");
+  if (inputs.fqdnLocks.has(fqdn)) {
+    return [
+      {
+        title: "Deployment Locked",
+        path: deployment.ordersPath,
+        level: "failure",
+        line: 0,
+        problems: [
+          `Changes to services using **${fqdn}** have been locked in this cluster. This is most likely because they are actively being migrated to a different cluster.`,
+        ],
+      },
+    ];
+  }
+
+  return [];
+}
+
+module.exports = fqdnLock;

--- a/checks/index.js
+++ b/checks/index.js
@@ -29,8 +29,8 @@ const restrictedBuckets = require("./restricted-buckets");
 const doubleQuotes = require("./double-quotes");
 const validBetas = require("./valid-betas");
 const shellcheck = require("./shellcheck");
-const validJsonArraysInBashCheck = require("./valid-json-arrays-in-bash");
-const entrypointRequiresCmdCheck = require("./entrypoint-requires-cmd");
+const validJsonArraysInBash = require("./valid-json-arrays-in-bash");
+const entrypointRequiresCmd = require("./entrypoint-requires-cmd");
 const jobsShouldUseBulkMail = require("./jobs-should-use-bulkmail");
 const noDuplicateForwardHostHeaders = require("./no-duplicate-forward-host-headers");
 const fqdnLock = require("./fqdn-lock");
@@ -68,8 +68,8 @@ module.exports = {
   doubleQuotes,
   validBetas,
   shellcheck,
-  validJsonArraysInBashCheck,
-  entrypointRequiresCmdCheck,
+  validJsonArraysInBash,
+  entrypointRequiresCmd,
   jobsShouldUseBulkMail,
   noDuplicateForwardHostHeaders,
   fqdnLock,

--- a/checks/index.js
+++ b/checks/index.js
@@ -33,6 +33,7 @@ const validJsonArraysInBashCheck = require("./valid-json-arrays-in-bash");
 const entrypointRequiresCmdCheck = require("./entrypoint-requires-cmd");
 const jobsShouldUseBulkMail = require("./jobs-should-use-bulkmail");
 const noDuplicateForwardHostHeaders = require("./no-duplicate-forward-host-headers");
+const fqdnLock = require("./fqdn-lock");
 
 /**
  * Exports all checks in an appropriate order
@@ -71,6 +72,7 @@ module.exports = {
   entrypointRequiresCmdCheck,
   jobsShouldUseBulkMail,
   noDuplicateForwardHostHeaders,
+  fqdnLock,
 
   /**
    *  This should always be after checks for orders and secrets.json, because it verifies that the

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ function getInputs() {
   const restrictedBuckets = core.getInput("restricted_buckets");
   const skipChecks = new Set(core.getInput("skip_checks").split(","));
   const epiqueryTemplatesRepo = core.getInput("epiquery_templates_repo");
+  const fqdnLocks = new Set(core.getInput("fqdn_locks").split(","));
 
   /** @type {ActionInputs} */
   return {
@@ -50,6 +51,7 @@ function getInputs() {
     restrictedBuckets,
     skipChecks,
     epiqueryTemplatesRepo,
+    fqdnLocks,
   };
 }
 

--- a/test/all-checks-mounted.js
+++ b/test/all-checks-mounted.js
@@ -1,0 +1,23 @@
+const { expect } = require("chai");
+const fs = require("fs").promises;
+const path = require("path");
+
+const checks = require("../checks");
+
+const exclusions = ["index.js", "template.js"];
+
+describe("All Checks Are Mounted", () => {
+  it("asserts all checks in the check directory have been mounted in checks/index.js", async () => {
+    const allChecks = await fs.readdir(path.join(process.cwd(), "checks"));
+    exclusions.forEach((filename) => {
+      const index = allChecks.indexOf(filename);
+      if (index > -1) {
+        allChecks.splice(index, 1);
+      }
+    });
+
+    const mountedChecks = Object.keys(checks);
+
+    expect(mountedChecks.length).to.deep.equal(allChecks.length);
+  });
+});

--- a/test/all-checks-mounted.js
+++ b/test/all-checks-mounted.js
@@ -20,4 +20,15 @@ describe("All Checks Are Mounted", () => {
 
     expect(mountedChecks.length).to.deep.equal(allChecks.length);
   });
+
+  it("all checks are included in readme", async () => {
+    const readme = await fs.readFile(
+      path.join(process.cwd(), "README.md"),
+      "utf8"
+    );
+
+    for (let checkName in checks) {
+      expect(readme).to.include(checkName);
+    }
+  });
 });

--- a/test/fqdn-lock.js
+++ b/test/fqdn-lock.js
@@ -1,0 +1,47 @@
+const { expect } = require("chai");
+const { fqdnLock } = require("../checks");
+
+describe("FQDN Lock", () => {
+  it("skips if no fqdn_locks are configured", async () => {
+    const deployment = {
+      serviceName: "something",
+      ordersContents: ["export GDS_FQDN='some.domain.com'"],
+      ordersPath: "something/orders",
+    };
+
+    const inputs = {
+      fqdnLocks: new Set(),
+    };
+
+    const results = await fqdnLock(deployment, {}, inputs);
+    expect(results.length).to.equal(0);
+  });
+
+  it("skips if a deployment does not have an orders file", async () => {
+    const deployment = {
+      serviceName: "something",
+    };
+
+    const inputs = {
+      fqdnLocks: new Set(["some.domain.com"]),
+    };
+
+    const results = await fqdnLock(deployment, {}, inputs);
+    expect(results.length).to.equal(0);
+  });
+
+  it("blocks deployments to specified fqdns", async () => {
+    const deployment = {
+      serviceName: "something",
+      ordersContents: ["export GDS_FQDN='some.domain.com'"],
+      ordersPath: "something/orders",
+    };
+    const inputs = {
+      fqdnLocks: new Set(["some.domain.com"]),
+    };
+
+    const results = await fqdnLock(deployment, {}, inputs);
+    expect(results.length).to.equal(1);
+    expect(results[0].level).to.equal("failure");
+  });
+});

--- a/typedefs.js
+++ b/typedefs.js
@@ -294,6 +294,7 @@
  * restrictedBuckets: string
  * skipChecks: Set<string>
  * epiqueryTemplatesRepo: string
+ * fqdnLocks: Set<string>
  * }} ActionInputs
  */
 


### PR DESCRIPTION
resolves #153 

Adds a "check" that blocks deployments to specified FQDN. This is intended to be used during cluster re-balancing, when services are being migrated to a different cluster.

Also adds tests to verify that all checks are mounted, and mentioned by name in the readme.