### PR TITLE
gds china forward host headers validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This is a github action for validating PRs to GDS Cluster Configs. It evaluates 
     - [noDuplicateForwardHostHeaders](#noduplicateforwardhostheaders)
     - [jobsShouldUseBulkMail](#jobsshouldusebulkmail)
     - [fqdnLock](#fqdnlock)
+    - [chinaForwardHostHeaders](#chinaforwardhostheaders)
   - [Adding Checks](#adding-checks)
     - [Testing locally](#testing-locally)
   - [Who's the goat?](#whos-the-goat)
@@ -280,6 +281,11 @@ Runs the [shellcheck](https://github.com/koalaman/shellcheck) utility on the ord
 
 ### fqdnLock
 - if `fqdn_locks` is configured and the deployment references that fqdn, it will be blocked
+
+
+### chinaForwardHostHeaders
+
+- GDS China is physically hosted in Mainland China, according to China regulations, websites' hosts physically located in Mainland China MUST have an ICP licensed domain to publish the website, so to use any domain related the feature in GDS China, we have to restrict our user to use ICP licensed domain.
 
 ## Adding Checks
 

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,10 @@ inputs:
     description: A comma separated list of FQDNs that should be blocked from deploying
     required: false
     default: ""
+  icp_domains:
+    description: a comma separated list of domains that are acceptable in china
+    required: false
+    default: glginc.cn
 runs:
   using: "node16"
   main: "index.js"

--- a/checks/china-forward-host-headers.js
+++ b/checks/china-forward-host-headers.js
@@ -1,0 +1,87 @@
+require("../typedefs");
+const log = require("loglevel");
+const {
+  isChinaClusterConfig,
+  getExportValue,
+  getLineNumber,
+  isAJob,
+  getClusterType,
+  escapeRegExp,
+} = require("../util");
+
+const checkMsg = "GDS China: Forward Host Headers Must Be ICP Licensed";
+
+/**
+ * GDS China is hosted in mainland china, and therefore can only use ICP licensed domains.
+ * @param {Deployment} deployment An object containing information about a deployment
+ * @param {GitHubContext} context The context object provided by github
+ * @param {ActionInputs} inputs The inputs (excluding the token) from the github action
+ * @param {function(string, (object | undefined)):Promise} httpGet
+ *
+ * @returns {Array<Result>}
+ */
+async function chinaForwardHostHeaders(deployment, context, inputs, httpGet) {
+  /**
+   * This check is really for a very specific subset of deployments.
+   * Most deployments will be able to skip this check.
+   */
+  const clusterType = getClusterType(context);
+  if (
+    !isChinaClusterConfig(context) ||
+    !deployment.ordersContents ||
+    clusterType === "jobs" ||
+    isAJob(deployment.ordersContents)
+  ) {
+    log.info(`${checkMsg} - Skipping ${deployment.serviceName}`);
+    return [];
+  }
+
+  // Check for existence of FORWARD_HOST_HEADERS variable
+  const forwardHostHeaderValue = getExportValue(
+    deployment.ordersContents.join("\n"),
+    "FORWARD_HOST_HEADERS"
+  );
+  if (!forwardHostHeaderValue) {
+    log.info(
+      `No Forward Host Headers Value Found - Skipping ${deployment.serviceName}`
+    );
+    return [];
+  }
+  log.info(`${checkMsg} - ${deployment.ordersPath}`);
+
+  /** @type {Array<Result>} */
+  const results = [];
+  const problems = [];
+  const allHeaders = forwardHostHeaderValue.split(",");
+  for (const header of allHeaders) {
+    let allowed = false;
+    for (const domain of inputs.icpDomains) {
+      const domainMatcher = new RegExp(escapeRegExp(domain));
+      if (domainMatcher.test(header)) {
+        allowed = true;
+      }
+    }
+
+    if (!allowed) {
+      problems.push(
+        `**${header}** must match one of **${allHeaders.join(", ")}**`
+      );
+    }
+  }
+
+  if (problems.length > 0) {
+    const exportRegex = /export FORWARD_HOST_HEADERS=/;
+    const line = getLineNumber(deployment.ordersContents, exportRegex);
+    results.push({
+      title: checkMsg,
+      line,
+      level: "failure",
+      path: deployment.ordersContents,
+      problems,
+    });
+  }
+
+  return results;
+}
+
+module.exports = chinaForwardHostHeaders;

--- a/checks/index.js
+++ b/checks/index.js
@@ -34,6 +34,7 @@ const entrypointRequiresCmd = require("./entrypoint-requires-cmd");
 const jobsShouldUseBulkMail = require("./jobs-should-use-bulkmail");
 const noDuplicateForwardHostHeaders = require("./no-duplicate-forward-host-headers");
 const fqdnLock = require("./fqdn-lock");
+const chinaForwardHostHeaders = require("./china-forward-host-headers");
 
 /**
  * Exports all checks in an appropriate order
@@ -73,11 +74,12 @@ module.exports = {
   jobsShouldUseBulkMail,
   noDuplicateForwardHostHeaders,
   fqdnLock,
+  chinaForwardHostHeaders,
 
   /**
-   *  This should always be after checks for orders and secrets.json, because it verifies that the
-   *  policy includes permissions that are implied by orders and secrets.json
-   * */
+   *  This should always be after checks for orders and secrets.json, because it verifies
+   *  that the policy includes permissions that are implied by orders and secrets.json
+   */
   policyJsonValid,
 
   /**

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ function getInputs() {
   const skipChecks = new Set(core.getInput("skip_checks").split(","));
   const epiqueryTemplatesRepo = core.getInput("epiquery_templates_repo");
   const fqdnLocks = new Set(core.getInput("fqdn_locks").split(","));
+  const icpDomains = core.getInput("icp_domains").split(",");
 
   /** @type {ActionInputs} */
   return {
@@ -52,6 +53,7 @@ function getInputs() {
     skipChecks,
     epiqueryTemplatesRepo,
     fqdnLocks,
+    icpDomains,
   };
 }
 

--- a/test/china-forward-host-headers.js
+++ b/test/china-forward-host-headers.js
@@ -1,0 +1,197 @@
+const { expect } = require("chai");
+const { chinaForwardHostHeaders } = require("../checks");
+
+describe("GDS China - Forward Host Headers Must Use ICP Domains", () => {
+  it("skips if it is not a gds china clusterconfig", async () => {
+    const deployment = {
+      serviceName: "something",
+      ordersPath: "something/orders",
+      ordersContents: ["export FORWARD_HOST_HEADERS='some.domain.com'"],
+    };
+
+    const context = {
+      payload: {
+        pull_request: {
+          base: {
+            repo: {
+              name: "gds.clusterconfig.s99", // Not a china config
+            },
+          },
+        },
+      },
+    };
+
+    const inputs = {
+      icpDomains: ["glginc.cn"],
+    };
+
+    const results = await chinaForwardHostHeaders(deployment, context, inputs);
+    expect(results.length).to.equal(0);
+  });
+
+  it("skips if there are no orders", async () => {
+    const deployment = {
+      serviceName: "something",
+      ordersPath: "something/orders",
+      // No orders contents
+    };
+
+    const context = {
+      payload: {
+        pull_request: {
+          base: {
+            repo: {
+              name: "gds.china.clusterconfig.s99", // is a china config
+            },
+          },
+        },
+      },
+    };
+
+    const inputs = {
+      icpDomains: ["glginc.cn"],
+    };
+
+    const results = await chinaForwardHostHeaders(deployment, context, inputs);
+    expect(results.length).to.equal(0);
+  });
+
+  it("skips if it is a jobs cluster", async () => {
+    const deployment = {
+      serviceName: "something",
+      ordersPath: "something/orders",
+      ordersContents: ["export FORWARD_HOST_HEADERS='some.domain.com'"],
+    };
+
+    const context = {
+      payload: {
+        pull_request: {
+          base: {
+            repo: {
+              name: "gds.clusterconfig.j99", // a jobs cluster
+            },
+          },
+        },
+      },
+    };
+
+    const inputs = {
+      icpDomains: ["glginc.cn"],
+    };
+
+    const results = await chinaForwardHostHeaders(deployment, context, inputs);
+    expect(results.length).to.equal(0);
+  });
+
+  it("skips if the orders are for a job", async () => {
+    const deployment = {
+      serviceName: "something",
+      ordersPath: "something/orders",
+      ordersContents: [
+        "export FORWARD_HOST_HEADERS='some.domain.com'",
+        "jobdeploy github/owner/repo/branch:tag",
+      ],
+    };
+
+    const context = {
+      payload: {
+        pull_request: {
+          base: {
+            repo: {
+              name: "gds.clusterconfig.s99", // Not a china config
+            },
+          },
+        },
+      },
+    };
+
+    const inputs = {
+      icpDomains: ["glginc.cn"],
+    };
+
+    const results = await chinaForwardHostHeaders(deployment, context, inputs);
+    expect(results.length).to.equal(0);
+  });
+
+  it("skips if no FORWARD_HOST_HEADERS are defined", async () => {
+    const deployment = {
+      serviceName: "something",
+      ordersPath: "something/orders",
+      ordersContents: [],
+    };
+
+    const context = {
+      payload: {
+        pull_request: {
+          base: {
+            repo: {
+              name: "gds.china.clusterconfig.s99",
+            },
+          },
+        },
+      },
+    };
+
+    const inputs = {
+      icpDomains: ["glginc.cn"],
+    };
+
+    const results = await chinaForwardHostHeaders(deployment, context, inputs);
+    expect(results.length).to.equal(0);
+  });
+
+  it("accepts orders that only use approved domains", async () => {
+    const deployment = {
+      serviceName: "something",
+      ordersPath: "something/orders",
+      ordersContents: ["export FORWARD_HOST_HEADERS='some.glginc.cn'"],
+    };
+
+    const context = {
+      payload: {
+        pull_request: {
+          base: {
+            repo: {
+              name: "gds.china.clusterconfig.s99",
+            },
+          },
+        },
+      },
+    };
+
+    const inputs = {
+      icpDomains: ["glginc.cn"],
+    };
+
+    const results = await chinaForwardHostHeaders(deployment, context, inputs);
+    expect(results.length).to.equal(0);
+  });
+
+  it("rejects orders that do not use an icp approved domain", async () => {
+    const deployment = {
+      serviceName: "something",
+      ordersPath: "something/orders",
+      ordersContents: ["export FORWARD_HOST_HEADERS='some.domain.com'"],
+    };
+
+    const context = {
+      payload: {
+        pull_request: {
+          base: {
+            repo: {
+              name: "gds.china.clusterconfig.s99",
+            },
+          },
+        },
+      },
+    };
+
+    const inputs = {
+      icpDomains: ["glginc.cn"],
+    };
+
+    const results = await chinaForwardHostHeaders(deployment, context, inputs);
+    expect(results.length).to.equal(1);
+    expect(results[0].level).to.equal("failure");
+  });
+});

--- a/test/no-duplicate-forward-host-headers.js
+++ b/test/no-duplicate-forward-host-headers.js
@@ -37,10 +37,6 @@ describe("No Duplicate Host Header Check", () => {
   });
 
   it("skips if there is no orders file", async () => {
-    const deployment = {
-      serviceName: "streamliner"
-    };
-
     const results = await noDupeHostHeaders(deployment, context);
     expect(results.length).to.equal(0);
   });
@@ -48,7 +44,7 @@ describe("No Duplicate Host Header Check", () => {
   it("skips if forward host headers is not defined", async () => {
     const deployment = {
       serviceName: "streamliner",
-      ordersContents: ["export TOM=pants"]
+      ordersContents: ["export TOM=pants"],
     };
 
     const results = await noDupeHostHeaders(deployment, context);
@@ -59,65 +55,67 @@ describe("No Duplicate Host Header Check", () => {
     const deployment = {
       serviceName: "streamliner",
       ordersContents: ['export FORWARD_HOST_HEADERS="single.glgroup.com'],
-      ordersPath: "streamliner/orders"
+      ordersPath: "streamliner/orders",
     };
 
     const inputs = {
       clusterRoot: path.join(process.cwd(), "test", "fixtures", "cc7"),
     };
 
-    const results = await noDupeHostHeaders(deployment,context,inputs);
+    const results = await noDupeHostHeaders(deployment, context, inputs);
     expect(results.length).to.equal(1);
     expect(results[0]).to.deep.equal({
       title: "Duplicate host header value",
       problems: [
         "No more than one unique FORWARD HOST HEADER value can be set per cluster config. The following value(s) are not unique for this cluster:",
-        "**single.glgroup.com** was found in the **test-service3** orders file."
+        "**single.glgroup.com** was found in the **test-service3** orders file.",
       ],
-      level: 'failure',
+      level: "failure",
       line: 1,
-      path: deployment.ordersPath
-    })
+      path: deployment.ordersPath,
+    });
   });
 
   it("fails if multiple duplicate host header values are detected in a cluster", async () => {
     const deployment = {
       serviceName: "streamliner",
-      ordersContents: ['export FORWARD_HOST_HEADERS="examplething.glgroup.com,mikes-really-long-name.glgroup.com"'],
-      ordersPath: "streamliner/orders"
+      ordersContents: [
+        'export FORWARD_HOST_HEADERS="examplething.glgroup.com,mikes-really-long-name.glgroup.com"',
+      ],
+      ordersPath: "streamliner/orders",
     };
 
     const inputs = {
       clusterRoot: path.join(process.cwd(), "test", "fixtures", "cc7"),
     };
 
-    const results = await noDupeHostHeaders(deployment,context,inputs);
+    const results = await noDupeHostHeaders(deployment, context, inputs);
     expect(results.length).to.equal(1);
     expect(results[0]).to.deep.equal({
       title: "Duplicate host header value",
       problems: [
         "No more than one unique FORWARD HOST HEADER value can be set per cluster config. The following value(s) are not unique for this cluster:",
         "**examplething.glgroup.com** was found in the **test-service2** orders file.",
-        "**mikes-really-long-name.glgroup.com** was found in the **test-service** orders file."
+        "**mikes-really-long-name.glgroup.com** was found in the **test-service** orders file.",
       ],
-      level: 'failure',
+      level: "failure",
       line: 1,
-      path: deployment.ordersPath
-    })
+      path: deployment.ordersPath,
+    });
   });
 
   it("it passes if forward host header is unique", async () => {
     const deployment = {
       serviceName: "test-service4",
       ordersContents: ['export FORWARD_HOST_HEADERS="unique.glgroup.com"'],
-      ordersPath: "test-service4/orders"
+      ordersPath: "test-service4/orders",
     };
 
     const inputs = {
       clusterRoot: path.join(process.cwd(), "test", "fixtures", "cc7"),
     };
 
-    const results = await noDupeHostHeaders(deployment,context,inputs);
+    const results = await noDupeHostHeaders(deployment, context, inputs);
     expect(results.length).to.equal(0);
   });
 });

--- a/test/secrets-exist.js
+++ b/test/secrets-exist.js
@@ -30,7 +30,6 @@ describe("Secrets Exist", () => {
 
     const results = await secretsExist(deployment, context, inputs);
 
-    console.log(results);
     expect(results.length).to.equal(0);
   });
 

--- a/typedefs.js
+++ b/typedefs.js
@@ -295,6 +295,7 @@
  * skipChecks: Set<string>
  * epiqueryTemplatesRepo: string
  * fqdnLocks: Set<string>
+ * icpDomains: Array<string>
  * }} ActionInputs
  */
 

--- a/util/generic.js
+++ b/util/generic.js
@@ -21,6 +21,11 @@ function isAJob(fileLines) {
   return isJobDeploy || isUnpublished;
 }
 
+function isChinaClusterConfig(context) {
+  const repo = context.payload.pull_request.base.repo.name;
+  return repo.startsWith("gds.china.");
+}
+
 /**
  * Read orders, secrets.json, and policy.json from the directory,
  * and split them by \n.
@@ -458,4 +463,5 @@ module.exports = {
   getClusterType,
   applyConfig,
   parseEnvVar,
+  isChinaClusterConfig,
 };

--- a/util/index.js
+++ b/util/index.js
@@ -37,6 +37,7 @@ const {
   getClusterType,
   applyConfig,
   parseEnvVar,
+  isChinaClusterConfig,
 } = require("./generic");
 
 module.exports = {
@@ -72,4 +73,5 @@ module.exports = {
   getClusterType,
   applyConfig,
   parseEnvVar,
+  isChinaClusterConfig,
 };


### PR DESCRIPTION
resolves #163 

Adds a new check that enforces
> GDS China is physically hosted in Mainland China, according to China regulations, websites' hosts physically located in Mainland China MUST have an ICP licensed domain to publish the website, so to use any domain related the feature in GDS China, we have to restrict our user to use ICP licensed domain.
> At this moment, we do have only one domain ICP licensed: *.glginc.cn