### PR TITLE
Inject .ccscreamer.json into checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,23 @@ The file looks like
 }
 ```
 
+### Check-Specific Configuration
+
+Some checks may implement configurable features.
+
+#### potentialSecrets.exclusions
+You may exclude specific environment variables in specific checks from being flagged as secrets. Use this feature only when you are confident the value of that environment variable will never be a secret.
+
+```json
+{
+  "service-name": {
+    "potentialSecrets": {
+      "exclusions": ["DATABASE_GLGLIVE_DRIVER"]
+    }
+  }
+}
+```
+
 ## Checks
 
 ### serviceName

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The file looks like
 
 ### Check-Specific Configuration
 
-Some checks may implement configurable features.
+Some checks may implement configurable features. All checks receive the configuration object via `inputs.config`.
 
 #### potentialSecrets.exclusions
 You may exclude specific environment variables in specific checks from being flagged as secrets. Use this feature only when you are confident the value of that environment variable will never be a secret.

--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ async function run() {
       );
     }
   }
+  inputs.config = config;
 
   const octokit = github.getOctokit(token);
 

--- a/test/potential-secrets.js
+++ b/test/potential-secrets.js
@@ -138,4 +138,26 @@ describe("Potential Secrets", () => {
 
     expect(results.length).to.equal(0);
   });
+
+  it("ignores variables that are configured in .ccscreamer.json", async () => {
+    const deployment = {
+      serviceName: "streamliner",
+      ordersPath: "streamliner/orders",
+      ordersContents: ["export CATS='RPp{2wTzvG8j4^9Du^r~_e%W'"],
+    };
+
+    const config = {
+      streamliner: {
+        potentialSecrets: {
+          exclusions: ["CATS"],
+        },
+      },
+    };
+
+    const inputs = { config };
+
+    const results = await potentialSecrets(deployment, {}, inputs);
+
+    expect(results.length).to.equal(0);
+  });
 });

--- a/typedefs.js
+++ b/typedefs.js
@@ -296,6 +296,7 @@
  * epiqueryTemplatesRepo: string
  * fqdnLocks: Set<string>
  * icpDomains: Array<string>
+ * config: Object
  * }} ActionInputs
  */
 

--- a/util/generic.js
+++ b/util/generic.js
@@ -431,6 +431,8 @@ function applyConfig({ config, serviceName, checkName, results }) {
       return result;
     });
   }
+
+  return results;
 }
 
 const envvar = /^(export\s+|)(\w+)=['"](.+)['"]/;


### PR DESCRIPTION
resolves #176

The config object is now attached to the `inputs` object, allowing checks to implement individual configuration behavior. The first example of this is the `potentialSecrets` check will now have configurable exclusions.

[it works](https://github.com/glg/cc-screamer-testing.s99/pull/75)