### PR TITLE
initial support of sub ecr images within gh repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,14 @@ You may exclude specific environment variables in specific checks from being fla
 
 - orders file must contain a deployment line
 - `dockerdeploy`
-  - should look like `github/<org>/<repo>/<branch>:<tag>`
+  - should look like `github/<org>/<repo>/<?path/><branch>:<tag>`
 - `jobdeploy`
-  - should look like `github/<org>/<repo>/<branch>:<tag>`
+  - should look like `github/<org>/<repo>/<?path/><branch>:<tag>`
 - `autodeploy`(legacy)
   - should look like `git@github.com:<org>/<repo>[.git]#<branch>`
 - repository name should only include alphanumeric characters and hyphens
 - repository name should start with a letter
+- path is optional
 - branch name should only include alphanumeric characters and hyphens
 - branch name should start with a letter
 - branch name cannot include `--`

--- a/checks/deployment-line.js
+++ b/checks/deployment-line.js
@@ -4,7 +4,7 @@ const log = require("loglevel");
 const dockerdeploy =
   /^dockerdeploy (?<source>\w+)\/(?<org>[\w-]+)\/(?<repo>.+?)\/((?<path>[\w\-\/]+)\/)?(?<branch>.+?):(?<tag>\w+)/;
 const jobdeploy =
-  /^jobdeploy (?<source>\w+)\/(?<org>[\w-]+)\/(?<repo>.+?)\/(?<branch>[^:]+):?(?<tag>[\w-]*)/;
+  /^jobdeploy (?<source>\w+)\/(?<org>[\w-]+)\/(?<repo>.+?)\/((?<path>[\w\-\/]+)\/)?(?<branch>.+?):(?<tag>\w+)/;
 const autodeploy =
   /^autodeploy\s+(git@github.com:|https:\/\/github\.com\/)(?<org>[\w-]+)\/(?<repo>[^#\.]+)(\.git|)#?(?<branch>.*)/;
 const validCharacters = /^[a-z][a-z0-9-]*$/;
@@ -54,7 +54,7 @@ async function validateDeploymentLine(deployment, context, inputs, httpGet) {
 
       if (!match) {
         problems.push(
-          "Incorrect Formatting: must be `dockerdeploy github/<org>/<repo>/<branch>:<tag>`"
+          "Incorrect Formatting: must be `dockerdeploy github/<org>/<repo>/<?path/><branch>:<tag>`"
         );
         break;
       }
@@ -81,7 +81,7 @@ async function validateDeploymentLine(deployment, context, inputs, httpGet) {
 
       if (!match) {
         problems.push(
-          "Incorrect Formatting: must be `jobdeploy github/<org>/<repo>/<branch>:<tag>`"
+          "Incorrect Formatting: must be `jobdeploy github/<org>/<repo>/<?path/><branch>:<tag>`"
         );
         break;
       }

--- a/checks/deployment-line.js
+++ b/checks/deployment-line.js
@@ -2,7 +2,7 @@ require("../typedefs");
 const log = require("loglevel");
 
 const dockerdeploy =
-  /^dockerdeploy (?<source>\w+)\/(?<org>[\w-]+)\/(?<repoAndPath>.+?)\/(?=[a-z]+:)(?<branch>.+?):(?<tag>\w+)/;
+  /^dockerdeploy (?<source>\w+)\/(?<org>[\w-]+)\/(?<repo>.+?)\/((?<path>[\w\-\/]+)\/)?(?<branch>.+?):(?<tag>\w+)/;
 const jobdeploy =
   /^jobdeploy (?<source>\w+)\/(?<org>[\w-]+)\/(?<repo>.+?)\/(?<branch>[^:]+):?(?<tag>[\w-]*)/;
 const autodeploy =
@@ -10,10 +10,7 @@ const autodeploy =
 const validCharacters = /^[a-z][a-z0-9-]*$/;
 
 function getDeployment(match) {
-  const { source, org, repoAndPath, branch, tag } = match.groups;
-  const hasPath = repoAndPath.includes("/")
-  const repo = hasPath ? repoAndPath.slice(0, repoAndPath.indexOf("/")) : repoAndPath;
-  const path = hasPath ? repoAndPath.slice(repoAndPath.indexOf("/") + 1) : undefined;
+  const { source, org, repo, path, branch, tag } = match.groups;
 
   return {
     source,

--- a/test/deployment-line.js
+++ b/test/deployment-line.js
@@ -66,12 +66,25 @@ describe("Deployment Line Check", () => {
     expect(results[0].problems.length).to.equal(0);
   });
 
-  it("works with nested ECR images", async () => {
+  it("works on dockerdeploy with nested ECR images", async () => {
     // works with dockerdeploy
     deployment = {
       serviceName: "sl-settings",
       ordersPath: "sl-settings/orders",
       ordersContents: ["dockerdeploy github/glg/sl2-mono/apps/settings/main:latest"],
+    };
+
+    results = await deploymentLineCheck(deployment, {}, {});
+
+    expect(results[0].problems.length).to.equal(0);
+  });
+
+  it("works on jobdeploy with nested ECR images", async () => {
+    // works with jobdeploy
+    deployment = {
+      serviceName: "sl-settings",
+      ordersPath: "sl-settings/orders",
+      ordersContents: ["jobdeploy github/glg/sl2-mono/apps/settings/main:latest"],
     };
 
     results = await deploymentLineCheck(deployment, {}, {});
@@ -90,7 +103,7 @@ describe("Deployment Line Check", () => {
 
     expect(results[0].problems.length).to.equal(1);
     expect(results[0].problems[0]).to.equal(
-      "Incorrect Formatting: must be `dockerdeploy github/<org>/<repo>/<branch>:<tag>`"
+      "Incorrect Formatting: must be `dockerdeploy github/<org>/<repo>/<?path/><branch>:<tag>`"
     );
     expect(results[0].level).to.equal("failure");
   });
@@ -106,7 +119,7 @@ describe("Deployment Line Check", () => {
 
     expect(results[0].problems.length).to.equal(1);
     expect(results[0].problems[0]).to.equal(
-      "Incorrect Formatting: must be `jobdeploy github/<org>/<repo>/<branch>:<tag>`"
+      "Incorrect Formatting: must be `jobdeploy github/<org>/<repo>/<?path/><branch>:<tag>`"
     );
     expect(results[0].level).to.equal("failure");
   });

--- a/test/deployment-line.js
+++ b/test/deployment-line.js
@@ -66,6 +66,19 @@ describe("Deployment Line Check", () => {
     expect(results[0].problems.length).to.equal(0);
   });
 
+  it("works with nested ECR images", async () => {
+    // works with dockerdeploy
+    deployment = {
+      serviceName: "sl-settings",
+      ordersPath: "sl-settings/orders",
+      ordersContents: ["dockerdeploy github/glg/sl2-mono/apps/settings/main:latest"],
+    };
+
+    results = await deploymentLineCheck(deployment, {}, {});
+
+    expect(results[0].problems.length).to.equal(0);
+  });
+
   it("rejects an improperly formatted dockerdeploy line", async () => {
     const deployment = {
       serviceName: "streamliner",


### PR DESCRIPTION
Fixes: https://github.com/glg-public/gds-cc-screamer/issues/236

This introduces support for monorepo like apps that require a `ecr_repository_override` value in the workflow file. In the case above, the user had a need for an image that was somewhat nested ([see it here](https://github.com/glg/sl2-mono/blob/27d4a9c08ff864eeeba6fa2c25f7dc8372c0b7f7/.github/workflows/build-and-push-to-ecr.yml#L102)). We have [introduced a regex that parses out an optional `path` value](https://github.com/glg-public/gds-cc-screamer/pull/244/files#diff-34915535e7d99fde40dc5d14ee48b5bbc77bc552b4c702eb9b9be22798074f7aR5) that we can expose later while still checking to make sure this is a valid path. [The image value is then later checked if it exists in ECR to truly validate the image](https://github.com/glg-public/gds-cc-screamer/pull/244/files#diff-34915535e7d99fde40dc5d14ee48b5bbc77bc552b4c702eb9b9be22798074f7aR169).

I've tested this works as expected on the s99 cluster as well. You can see multiple commit and actions runs displaying my tests of multiple scenarios. https://github.com/glg/cc-screamer-testing.s99/pull/94