### PR TITLE
Allow slashes in the branch name for monorepo deployments

### DIFF
--- a/checks/deployment-line.js
+++ b/checks/deployment-line.js
@@ -7,7 +7,7 @@ const jobdeploy =
   /^jobdeploy (?<source>\w+)\/(?<org>[\w-]+)\/(?<repo>.+?)\/(?<branch>[^:]+):?(?<tag>[\w-]*)/;
 const autodeploy =
   /^autodeploy\s+(git@github.com:|https:\/\/github\.com\/)(?<org>[\w-]+)\/(?<repo>[^#\.]+)(\.git|)#?(?<branch>.*)/;
-const validCharacters = /^[a-z][a-z0-9-]*$/;
+const validCharacters = /^[a-z][a-z0-9-\/]*$/;
 
 function getDeployment(match) {
   const { source, org, repo, branch, tag } = match.groups;


### PR DESCRIPTION
This should fix monorepo deployments, and other issues like #243 