### PR TITLE
Add new check: Validate capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This is a github action for validating PRs to GDS Cluster Configs. It evaluates 
     - [jobsShouldUseBulkMail](#jobsshouldusebulkmail)
     - [fqdnLock](#fqdnlock)
     - [chinaForwardHostHeaders](#chinaforwardhostheaders)
+    - [validateCapcity](#validateCapcity)
   - [Adding Checks](#adding-checks)
     - [Testing locally](#testing-locally)
   - [Who's the goat?](#whos-the-goat)
@@ -306,6 +307,10 @@ Runs the [shellcheck](https://github.com/koalaman/shellcheck) utility on the ord
 ### chinaForwardHostHeaders
 
 - GDS China is physically hosted in Mainland China, according to China regulations, websites' hosts physically located in Mainland China MUST have an ICP licensed domain to publish the website, so to use any domain related the feature in GDS China, we have to restrict our user to use ICP licensed domain.
+
+### validateCapcity
+
+- The max capacity can not be less than min capacity, check the value and block the merge when it's be detected.
 
 ## Adding Checks
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This is a github action for validating PRs to GDS Cluster Configs. It evaluates 
     - [jobsShouldUseBulkMail](#jobsshouldusebulkmail)
     - [fqdnLock](#fqdnlock)
     - [chinaForwardHostHeaders](#chinaforwardhostheaders)
-    - [validateCapcity](#validateCapcity)
+    - [validateCapacity](#validateCapacity)
   - [Adding Checks](#adding-checks)
     - [Testing locally](#testing-locally)
   - [Who's the goat?](#whos-the-goat)
@@ -308,7 +308,7 @@ Runs the [shellcheck](https://github.com/koalaman/shellcheck) utility on the ord
 
 - GDS China is physically hosted in Mainland China, according to China regulations, websites' hosts physically located in Mainland China MUST have an ICP licensed domain to publish the website, so to use any domain related the feature in GDS China, we have to restrict our user to use ICP licensed domain.
 
-### validateCapcity
+### validateCapacity
 
 - The max capacity can not be less than min capacity, check the value and block the merge when it's be detected.
 

--- a/checks/china-forward-host-headers.js
+++ b/checks/china-forward-host-headers.js
@@ -76,7 +76,7 @@ async function chinaForwardHostHeaders(deployment, context, inputs, httpGet) {
       title: checkMsg,
       line,
       level: "failure",
-      path: deployment.ordersContents,
+      path: deployment.ordersPath,
       problems,
     });
   }

--- a/checks/index.js
+++ b/checks/index.js
@@ -35,6 +35,7 @@ const jobsShouldUseBulkMail = require("./jobs-should-use-bulkmail");
 const noDuplicateForwardHostHeaders = require("./no-duplicate-forward-host-headers");
 const fqdnLock = require("./fqdn-lock");
 const chinaForwardHostHeaders = require("./china-forward-host-headers");
+const validateCapcity = require("./validate-capacity.js");
 
 /**
  * Exports all checks in an appropriate order
@@ -75,6 +76,7 @@ module.exports = {
   noDuplicateForwardHostHeaders,
   fqdnLock,
   chinaForwardHostHeaders,
+  validateCapcity,
 
   /**
    *  This should always be after checks for orders and secrets.json, because it verifies

--- a/checks/index.js
+++ b/checks/index.js
@@ -35,7 +35,7 @@ const jobsShouldUseBulkMail = require("./jobs-should-use-bulkmail");
 const noDuplicateForwardHostHeaders = require("./no-duplicate-forward-host-headers");
 const fqdnLock = require("./fqdn-lock");
 const chinaForwardHostHeaders = require("./china-forward-host-headers");
-const validateCapcity = require("./validate-capacity.js");
+const validateCapacity = require("./validate-capacity.js");
 
 /**
  * Exports all checks in an appropriate order
@@ -76,7 +76,7 @@ module.exports = {
   noDuplicateForwardHostHeaders,
   fqdnLock,
   chinaForwardHostHeaders,
-  validateCapcity,
+  validateCapacity,
 
   /**
    *  This should always be after checks for orders and secrets.json, because it verifies

--- a/checks/validate-capacity.js
+++ b/checks/validate-capacity.js
@@ -21,7 +21,7 @@ const checkMsg = "Maximum capacity cannot be less than minimum capacity.";
  * @returns {Array<Result>}
 */
 
-async function validateCapcity(deployment) {
+async function validateCapacity(deployment) {
 
   if (!deployment.ordersContents) {
     log.info(`No Orders Present - Skipping ${deployment.serviceName}`);
@@ -30,8 +30,8 @@ async function validateCapcity(deployment) {
 
   let hasMax = false;
   let hasMin = false;
-  const defaultEcsTaskMaxCapcity = 4;
-  const defaultEcsTaskMinCapcity = 2;
+  const defaultEcsTaskMaxCapacity = 4;
+  const defaultEcsTaskMinCapacity = 2;
 
   const flattenedOrder=deployment.ordersContents.join("\n");
 
@@ -45,15 +45,15 @@ async function validateCapcity(deployment) {
   };
 
 
-  const ecsTaskMaxCapcity = !hasMax ? defaultEcsTaskMaxCapcity : parseInt(flattenedOrder.match(/export\s+ECS_TASK_MAX_CAPACITY=["|']?(\d+)["|']?/)[1]);
-  const ecsTaskMinCapcity = !hasMin ? defaultEcsTaskMinCapcity : parseInt(flattenedOrder.match(/export\s+ECS_TASK_MIN_CAPACITY=["|']?(\d+)["|']?/)[1]);
+  const ecsTaskMaxCapacity = !hasMax ? defaultEcsTaskMaxCapacity : parseInt(flattenedOrder.match(/export\s+ECS_TASK_MAX_CAPACITY=["|']?(\d+)["|']?/)[1]);
+  const ecsTaskMinCapacity = !hasMin ? defaultEcsTaskMinCapacity : parseInt(flattenedOrder.match(/export\s+ECS_TASK_MIN_CAPACITY=["|']?(\d+)["|']?/)[1]);
 
   /** @type {Array<Result>} */
   const results = [];
   const problems = [];
   let allowed = false;
   
-  if (ecsTaskMaxCapcity >= ecsTaskMinCapcity) {
+  if (ecsTaskMaxCapacity >= ecsTaskMinCapacity) {
     allowed = true;
   }
 
@@ -96,4 +96,4 @@ async function validateCapcity(deployment) {
   return results;
 }
 
-module.exports = validateCapcity;
+module.exports = validateCapacity;

--- a/checks/validate-capacity.js
+++ b/checks/validate-capacity.js
@@ -1,0 +1,99 @@
+require("../typedefs");
+const log = require("loglevel");
+const {
+  getExportValue,
+  getLineNumber,
+  isAJob,
+  getClusterType,
+  escapeRegExp,
+} = require("../util");
+
+const checkMsg = "Maximum capacity cannot be less than minimum capacity.";
+
+/**
+ * The default value of ECS_TASK_MAX_CAPACITY is 4 and the default value of ECS_TASK_MIN_CAPACITY is 2.
+ * User may have given the value to ECS_TASK_MAX_CAPACITY, which is lower than the default value of
+ * ECS_TASK_MIN_CAPACITY, which will therefore cause deployment failure with following error messages:
+ * Error creating application autoscaling target: ValidationException: Maximum capacity cannot be less than minimum capacity
+ *
+ * @param {Deployment} deployment An object containing information about a deployment
+ *
+ * @returns {Array<Result>}
+*/
+
+async function validateCapcity(deployment) {
+
+  if (!deployment.ordersContents) {
+    log.info(`No Orders Present - Skipping ${deployment.serviceName}`);
+    return [];
+  }
+
+  let hasMax = false;
+  let hasMin = false;
+  const defaultEcsTaskMaxCapcity = 4;
+  const defaultEcsTaskMinCapcity = 2;
+
+  const flattenedOrder=deployment.ordersContents.join("\n");
+
+  hasMax = /export\s+ECS_TASK_MAX_CAPACITY=["|']?(\d+)["|']?/.test(flattenedOrder) || hasMax;
+  hasMin = /export\s+ECS_TASK_MIN_CAPACITY=["|']?(\d+)["|']?/.test(flattenedOrder) || hasMin;
+
+  // when there is no value has been defined, we shall go with default value, we can skip this check.
+  if (!hasMax && !hasMin) {
+    log.info(`No custom value has been defined - Skipping ${deployment.serviceName}`);
+    return[];
+  };
+
+
+  const ecsTaskMaxCapcity = !hasMax ? defaultEcsTaskMaxCapcity : parseInt(flattenedOrder.match(/export\s+ECS_TASK_MAX_CAPACITY=["|']?(\d+)["|']?/)[1]);
+  const ecsTaskMinCapcity = !hasMin ? defaultEcsTaskMinCapcity : parseInt(flattenedOrder.match(/export\s+ECS_TASK_MIN_CAPACITY=["|']?(\d+)["|']?/)[1]);
+
+  /** @type {Array<Result>} */
+  const results = [];
+  const problems = [];
+  let allowed = false;
+  
+  if (ecsTaskMaxCapcity >= ecsTaskMinCapcity) {
+    allowed = true;
+  }
+
+  if (!allowed) {
+
+    if (hasMax && !hasMin) {
+      // Below is the message when developer has set the override value of ECS_TASK_MAX_CAPACITY, the value is less than the default value of ECS_TASK_MIN_CAPACITY.
+      problems.push(
+        `The value of **ECS_TASK_MAX_CAPACITY** is less than the default value of **ECS_TASK_MIN_CAPACITY**, click [here](https://blog.glgresearch.com/know/glg-deployment-system-gds/cluster-configuration/#env-ecs_task_min_capacity) to find the default value.`
+      );
+    }
+
+    if (hasMin && !hasMax) {
+      // Below is the message when developer has set the override value of ECS_TASK_MIN_CAPACITY, the value is greater than the default value of ECS_TASK_MAX_CAPACITY.
+      problems.push(
+        `The value of **ECS_TASK_MIN_CAPACITY** is greater than the default value of **ECS_TASK_MAX_CAPACITY**, click [here](https://blog.glgresearch.com/know/glg-deployment-system-gds/cluster-configuration/#env-ecs_task_max_capacity) to find the default value.`
+      );
+    }
+
+    if (hasMax && hasMin) {
+      // Below message should be poped when developer has set the override value to both ECS_TASK_MAX_CAPACITY and ECS_TASK_MIN_CAPACITY.
+      problems.push(
+        `Value of **ECS_TASK_MAX_CAPACITY** cannot be less than **ECS_TASK_MIN_CAPACITY**.`
+      );
+    }
+  };
+
+  if (problems.length > 0) {
+    const exportRegex = !hasMax ? /export ECS_TASK_MIN_CAPACITY=/ : /export ECS_TASK_MAX_CAPACITY=/;
+    const line = getLineNumber(deployment.ordersContents, exportRegex);
+    results.push({
+      title: checkMsg,
+      line,
+      level: "failure",
+      path: deployment.ordersContents,
+      problems,
+    });
+  }
+
+  return results;
+}
+
+module.exports = validateCapcity;

--- a/checks/validate-capacity.js
+++ b/checks/validate-capacity.js
@@ -88,7 +88,7 @@ async function validateCapcity(deployment) {
       title: checkMsg,
       line,
       level: "failure",
-      path: deployment.ordersContents,
+      path: deployment.ordersPath,
       problems,
     });
   }

--- a/checks/validate-capacity.js
+++ b/checks/validate-capacity.js
@@ -28,15 +28,13 @@ async function validateCapacity(deployment) {
     return [];
   }
 
-  let hasMax = false;
-  let hasMin = false;
   const defaultEcsTaskMaxCapacity = 4;
   const defaultEcsTaskMinCapacity = 2;
 
   const flattenedOrder=deployment.ordersContents.join("\n");
 
-  hasMax = /export\s+ECS_TASK_MAX_CAPACITY=["|']?(\d+)["|']?/.test(flattenedOrder) || hasMax;
-  hasMin = /export\s+ECS_TASK_MIN_CAPACITY=["|']?(\d+)["|']?/.test(flattenedOrder) || hasMin;
+  const hasMax = /export\s+ECS_TASK_MAX_CAPACITY=["|']?(\d+)["|']?/.test(flattenedOrder);
+  const hasMin = /export\s+ECS_TASK_MIN_CAPACITY=["|']?(\d+)["|']?/.test(flattenedOrder);
 
   // when there is no value has been defined, we shall go with default value, we can skip this check.
   if (!hasMax && !hasMin) {

--- a/checks/validate-cron.js
+++ b/checks/validate-cron.js
@@ -32,7 +32,7 @@ async function validateCron(deployment) {
         title: "Jobs must define a cron statement",
         level: "failure",
         line: 0,
-        path: deployment.ordersContents,
+        path: deployment.ordersPath,
         problems: [
           "Your job must define a valid cron schedule in the environment variable `ECS_SCHEDULED_TASK_CRON`",
         ],

--- a/test/fixtures/capacity-custom-both
+++ b/test/fixtures/capacity-custom-both
@@ -1,0 +1,10 @@
+ # THIS IS A TEST BRANCH
+
+# Env vars
+export INSERT_RECORDS="True"
+export ENV="prod"
+export LOGLEVEL="debug"
+export ECS_TASK_MIN_CAPACITY=6
+export ECS_TASK_MAX_CAPACITY=3
+
+autodeploy github/owner/repo/test:latest

--- a/test/fixtures/capacity-custom-max
+++ b/test/fixtures/capacity-custom-max
@@ -1,0 +1,9 @@
+ # THIS IS A TEST BRANCH
+
+# Env vars
+export INSERT_RECORDS="True"
+export ENV="prod"
+export LOGLEVEL="debug"
+export ECS_TASK_MAX_CAPACITY=1
+
+autodeploy github/owner/repo/test:latest

--- a/test/fixtures/capacity-custom-min
+++ b/test/fixtures/capacity-custom-min
@@ -1,0 +1,9 @@
+ # THIS IS A TEST BRANCH
+
+# Env vars
+export INSERT_RECORDS="True"
+export ENV="prod"
+export LOGLEVEL="debug"
+export ECS_TASK_MIN_CAPACITY="6"
+
+autodeploy github/owner/repo/test:latest

--- a/test/fixtures/capacity-default
+++ b/test/fixtures/capacity-default
@@ -1,0 +1,9 @@
+
+ # THIS IS A TEST BRANCH
+
+# Env vars
+export INSERT_RECORDS="True"
+export ENV="prod"
+export LOGLEVEL="debug"
+
+autodeploy github/owner/repo/test:latest

--- a/test/validate-capacity.js
+++ b/test/validate-capacity.js
@@ -35,6 +35,7 @@ describe("Validate Capacity numbers", () => {
     expect(results.length).to.equal(1);
     expect(results[0].level).to.equal("failure");
     expect(results[0].path).to.equal(deployment.ordersPath);
+    expect(results[0].problems[0]).to.equal(`The value of **ECS_TASK_MAX_CAPACITY** is less than the default value of **ECS_TASK_MIN_CAPACITY**, click [here](https://blog.glgresearch.com/know/glg-deployment-system-gds/cluster-configuration/#env-ecs_task_min_capacity) to find the default value.`);
   });
 
   it("rejects when custom value of ECS_TASK_MIN_CAPACITY is greater equal default value of ECS_TASK_MAX_CAPACITY", async () => {
@@ -52,6 +53,7 @@ describe("Validate Capacity numbers", () => {
     expect(results.length).to.equal(1);
     expect(results[0].level).to.equal("failure");
     expect(results[0].path).to.equal(deployment.ordersPath);
+    expect(results[0].problems[0]).to.equal(`The value of **ECS_TASK_MIN_CAPACITY** is greater than the default value of **ECS_TASK_MAX_CAPACITY**, click [here](https://blog.glgresearch.com/know/glg-deployment-system-gds/cluster-configuration/#env-ecs_task_max_capacity) to find the default value.`);
   });
 
   it("rejects when custom value of ECS_TASK_MAX_CAPACITY less than custom value of ECS_TASK_MAX_CAPACITY", async () => {
@@ -69,5 +71,6 @@ describe("Validate Capacity numbers", () => {
     expect(results.length).to.equal(1);
     expect(results[0].level).to.equal("failure");
     expect(results[0].path).to.equal(deployment.ordersPath);
+    expect(results[0].problems[0]).to.equal(`Value of **ECS_TASK_MAX_CAPACITY** cannot be less than **ECS_TASK_MIN_CAPACITY**.`);
   });
 });

--- a/test/validate-capacity.js
+++ b/test/validate-capacity.js
@@ -1,5 +1,5 @@
 const { expect } = require("chai");
-const { validateCapcity } = require("../checks");
+const { validateCapacity } = require("../checks");
 const fs = require("fs").promises;
 const path = require("path");
 const fixturesDir = path.join(process.cwd(), "test", "fixtures");
@@ -16,7 +16,7 @@ describe("Validate Capacity numbers", () => {
       ordersPath: "something/orders",
     };
 
-    const results = await validateCapcity(deployment);
+    const results = await validateCapacity(deployment);
     expect(results.length).to.equal(0);
   });
 
@@ -31,7 +31,7 @@ describe("Validate Capacity numbers", () => {
       ordersPath: "something/orders",
     };
 
-    const results = await validateCapcity(deployment);
+    const results = await validateCapacity(deployment);
     expect(results.length).to.equal(1);
     expect(results[0].level).to.equal("failure");
     expect(results[0].path).to.equal(deployment.ordersPath);
@@ -48,7 +48,7 @@ describe("Validate Capacity numbers", () => {
       ordersPath: "something/orders",
     };
 
-    const results = await validateCapcity(deployment);
+    const results = await validateCapacity(deployment);
     expect(results.length).to.equal(1);
     expect(results[0].level).to.equal("failure");
     expect(results[0].path).to.equal(deployment.ordersPath);
@@ -65,7 +65,7 @@ describe("Validate Capacity numbers", () => {
       ordersPath: "something/orders",
     };
 
-    const results = await validateCapcity(deployment);
+    const results = await validateCapacity(deployment);
     expect(results.length).to.equal(1);
     expect(results[0].level).to.equal("failure");
     expect(results[0].path).to.equal(deployment.ordersPath);

--- a/test/validate-capacity.js
+++ b/test/validate-capacity.js
@@ -1,0 +1,70 @@
+const { expect } = require("chai");
+const { validateCapcity } = require("../checks");
+const fs = require("fs").promises;
+const path = require("path");
+const fixturesDir = path.join(process.cwd(), "test", "fixtures");
+
+describe("Validate Capacity numbers", () => {
+  it("Skips if it goes with default.", async () => {
+    const orders = await fs.readFile(
+      path.join(fixturesDir, "capacity-default"),
+      "utf8"
+    );
+    const deployment = {
+      serviceName: "something",
+      ordersContents: orders.split("\n"),
+      ordersPath: "something/orders",
+    };
+
+    const results = await validateCapcity(deployment);
+    expect(results.length).to.equal(0);
+  });
+
+  it("rejects when custom value of ECS_TASK_MAX_CAPACITY is less than default value of ECS_TASK_MIN_CAPACITY", async () => {
+    const orders = await fs.readFile(
+      path.join(fixturesDir, "capacity-custom-max"),
+      "utf8"
+    );
+    const deployment = {
+      serviceName: "something",
+      ordersContents: orders.split("\n"),
+      ordersPath: "something/orders",
+    };
+
+    const results = await validateCapcity(deployment);
+    expect(results.length).to.equal(1);
+    expect(results[0].level).to.equal("failure");
+  });
+
+  it("rejects when custom value of ECS_TASK_MIN_CAPACITY is greater equal default value of ECS_TASK_MAX_CAPACITY", async () => {
+    const orders = await fs.readFile(
+      path.join(fixturesDir, "capacity-custom-min"),
+      "utf8"
+    );
+    const deployment = {
+      serviceName: "something",
+      ordersContents: orders.split("\n"),
+      ordersPath: "something/orders",
+    };
+
+    const results = await validateCapcity(deployment);
+    expect(results.length).to.equal(1);
+    expect(results[0].level).to.equal("failure");
+  });
+
+  it("rejects when custom value of ECS_TASK_MAX_CAPACITY less than custom value of ECS_TASK_MAX_CAPACITY", async () => {
+    const orders = await fs.readFile(
+      path.join(fixturesDir, "capacity-custom-both"),
+      "utf8"
+    );
+    const deployment = {
+      serviceName: "something",
+      ordersContents: orders.split("\n"),
+      ordersPath: "something/orders",
+    };
+
+    const results = await validateCapcity(deployment);
+    expect(results.length).to.equal(1);
+    expect(results[0].level).to.equal("failure");
+  });
+});

--- a/test/validate-capacity.js
+++ b/test/validate-capacity.js
@@ -34,6 +34,7 @@ describe("Validate Capacity numbers", () => {
     const results = await validateCapcity(deployment);
     expect(results.length).to.equal(1);
     expect(results[0].level).to.equal("failure");
+    expect(results[0].path).to.equal(deployment.ordersPath);
   });
 
   it("rejects when custom value of ECS_TASK_MIN_CAPACITY is greater equal default value of ECS_TASK_MAX_CAPACITY", async () => {
@@ -50,6 +51,7 @@ describe("Validate Capacity numbers", () => {
     const results = await validateCapcity(deployment);
     expect(results.length).to.equal(1);
     expect(results[0].level).to.equal("failure");
+    expect(results[0].path).to.equal(deployment.ordersPath);
   });
 
   it("rejects when custom value of ECS_TASK_MAX_CAPACITY less than custom value of ECS_TASK_MAX_CAPACITY", async () => {
@@ -66,5 +68,6 @@ describe("Validate Capacity numbers", () => {
     const results = await validateCapcity(deployment);
     expect(results.length).to.equal(1);
     expect(results[0].level).to.equal("failure");
+    expect(results[0].path).to.equal(deployment.ordersPath);
   });
 });

--- a/test/validate-capacity.js
+++ b/test/validate-capacity.js
@@ -4,6 +4,24 @@ const fs = require("fs").promises;
 const path = require("path");
 const fixturesDir = path.join(process.cwd(), "test", "fixtures");
 
+const validateClusterConfig = async fixture => {
+  const orders = await fs.readFile(
+    path.join(fixturesDir, fixture),
+    "utf8"
+  );
+  const deployment = {
+    serviceName: "something",
+    ordersContents: orders.split("\n"),
+    ordersPath: "something/orders",
+  };
+
+  const results = await validateCapacity(deployment);
+  expect(results.length).to.equal(1);
+  expect(results[0].level).to.equal("failure");
+  expect(results[0].path).to.equal(deployment.ordersPath);
+  return results
+}
+
 describe("Validate Capacity numbers", () => {
   it("Skips if it goes with default.", async () => {
     const orders = await fs.readFile(
@@ -21,56 +39,17 @@ describe("Validate Capacity numbers", () => {
   });
 
   it("rejects when custom value of ECS_TASK_MAX_CAPACITY is less than default value of ECS_TASK_MIN_CAPACITY", async () => {
-    const orders = await fs.readFile(
-      path.join(fixturesDir, "capacity-custom-max"),
-      "utf8"
-    );
-    const deployment = {
-      serviceName: "something",
-      ordersContents: orders.split("\n"),
-      ordersPath: "something/orders",
-    };
-
-    const results = await validateCapacity(deployment);
-    expect(results.length).to.equal(1);
-    expect(results[0].level).to.equal("failure");
-    expect(results[0].path).to.equal(deployment.ordersPath);
+    const results = await validateClusterConfig("capacity-custom-max")
     expect(results[0].problems[0]).to.equal(`The value of **ECS_TASK_MAX_CAPACITY** is less than the default value of **ECS_TASK_MIN_CAPACITY**, click [here](https://blog.glgresearch.com/know/glg-deployment-system-gds/cluster-configuration/#env-ecs_task_min_capacity) to find the default value.`);
   });
 
   it("rejects when custom value of ECS_TASK_MIN_CAPACITY is greater equal default value of ECS_TASK_MAX_CAPACITY", async () => {
-    const orders = await fs.readFile(
-      path.join(fixturesDir, "capacity-custom-min"),
-      "utf8"
-    );
-    const deployment = {
-      serviceName: "something",
-      ordersContents: orders.split("\n"),
-      ordersPath: "something/orders",
-    };
-
-    const results = await validateCapacity(deployment);
-    expect(results.length).to.equal(1);
-    expect(results[0].level).to.equal("failure");
-    expect(results[0].path).to.equal(deployment.ordersPath);
+    const results = await validateClusterConfig("capacity-custom-min")
     expect(results[0].problems[0]).to.equal(`The value of **ECS_TASK_MIN_CAPACITY** is greater than the default value of **ECS_TASK_MAX_CAPACITY**, click [here](https://blog.glgresearch.com/know/glg-deployment-system-gds/cluster-configuration/#env-ecs_task_max_capacity) to find the default value.`);
   });
 
   it("rejects when custom value of ECS_TASK_MAX_CAPACITY less than custom value of ECS_TASK_MAX_CAPACITY", async () => {
-    const orders = await fs.readFile(
-      path.join(fixturesDir, "capacity-custom-both"),
-      "utf8"
-    );
-    const deployment = {
-      serviceName: "something",
-      ordersContents: orders.split("\n"),
-      ordersPath: "something/orders",
-    };
-
-    const results = await validateCapacity(deployment);
-    expect(results.length).to.equal(1);
-    expect(results[0].level).to.equal("failure");
-    expect(results[0].path).to.equal(deployment.ordersPath);
+    const results = await validateClusterConfig("capacity-custom-both")
     expect(results[0].problems[0]).to.equal(`Value of **ECS_TASK_MAX_CAPACITY** cannot be less than **ECS_TASK_MIN_CAPACITY**.`);
   });
 });


### PR DESCRIPTION
### New check: Validate capacity

- The value of `ECS_TASK_MAX_CAPACITY` shall never less than `ECS_TASK_MIN_CAPACITY`
- We have default value, it will handle the default number as well.
- Unit test has been added
- Correct some code with the value passed to `results.path`

https://github.com/glg-public/gds-cc-screamer/issues/251